### PR TITLE
Rename Dilithium to ML-DSA

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,13 @@
             date: "May 2020",
             publisher: "National Institute of Standards and Technology",
             href: "https://doi.org/10.6028/NIST.SP.800-57pt1r5"
+          },
+          "FIPS-204": {
+            title: "Module-Lattice-Based Digital Signature Standard",
+            authors: [],
+            date: "August 2023",
+            publisher: "Federal Information Processing Standards",
+            href: "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.ipd.pdf"
           }
         },
         xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY"],
@@ -302,7 +309,7 @@ data integrity proofs, such as digital signatures.
         <p>
 These verification methods are used to verify Data Integrity Proofs
 [[VC-DATA-INTEGRITY]] produced using ML-DSA-44 cryptographic key material
-that is compliant with <span class="issue">cite ML-DSA spec</span>.
+that is compliant with <span class="issue">cite ML-DSA spec - I belive this is FIPS-204</span>.
 The encoding formats for these key types are provided in this section. Lossless
 cryptographic key transformation processes that result in equivalent
 cryptographic key material MAY be used during the processing of digital

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@ data integrity proofs, such as digital signatures.
         <p>
 These verification methods are used to verify Data Integrity Proofs
 [[VC-DATA-INTEGRITY]] produced using ML-DSA-44 cryptographic key material
-that is compliant with <span class="issue">cite ML-DSA spec - I belive this is FIPS-204</span>.
+that is compliant with [[FIPS-204]].
 The encoding formats for these key types are provided in this section. Lossless
 cryptographic key transformation processes that result in equivalent
 cryptographic key material MAY be used during the processing of digital
@@ -470,7 +470,7 @@ The `cryptosuite` property of the proof MUST be
 The value of the `proofValue` property of the proof MUST be an ML-DSA-44
 signature produced according to using the algorithms specified in section
 [[[#algorithms]]], encoded according
-to <span class="issue">What is the encoding?</span>??? encoded using the base-64-url-nopad header and
+to [[FIPS-204]], then encoded using the base-64-url-nopad header and
 alphabet as described in the
 <a href="https://www.w3.org/TR/vc-data-integrity/#multibase-0">
 Multibase section</a> of [[VC-DATA-INTEGRITY]].
@@ -905,8 +905,8 @@ bytes) associated with the verification method identified by the
 |options|.|verificationMethod| value.
             </li>
             <li>
-Let |proofBytes| be the result of applying the ML_DSA_44
-Signature Algorithm [???REF???], with |hashData| as the data
+Let |proofBytes| be the result of applying the ML-DSA-44
+Signature Algorithm [[FIPS-204]], with |hashData| as the data
 to be signed using the private key specified by |privateKeyBytes|.
 |proofBytes| will be exactly 2420 bytes in size.
             </li>
@@ -944,7 +944,7 @@ Section 4: Retrieve Verification Method</a>.
             </li>
             <li>
 Let |verificationResult| be the result of applying the verification
-algorithm ML-DSA-44 Digital Signature Algorithm [???REF???],
+algorithm ML-DSA-44 Digital Signature Algorithm [[FIPS-204]],
 with |hashData| as the data to be verified against the
 |proofBytes| using the public key specified by
 |publicKeyBytes|.

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@ the Data Integrity [[VC-DATA-INTEGRITY]] specification.
 This specification uses either the RDF Dataset Canonicalization Algorithm
 [[RDF-CANON]] or the JSON Canonicalization Scheme [[RFC8785]] to transform the
 input document into its canonical form. It uses SHA-256 [[RFC6234]] as the
-message digest algorithm and Dilithium as the signature algorithm.
+message digest algorithm and ml-dsa-44 as the signature algorithm.
       </p>
 
       <section id="terminology">
@@ -301,8 +301,8 @@ data integrity proofs, such as digital signatures.
 
         <p>
 These verification methods are used to verify Data Integrity Proofs
-[[VC-DATA-INTEGRITY]] produced using Dilithium cryptographic key material
-that is compliant with <span class="issue">cite Dilithium spec</span>.
+[[VC-DATA-INTEGRITY]] produced using ML-DSA-44 cryptographic key material
+that is compliant with <span class="issue">cite ML-DSA spec</span>.
 The encoding formats for these key types are provided in this section. Lossless
 cryptographic key transformation processes that result in equivalent
 cryptographic key material MAY be used during the processing of digital
@@ -320,12 +320,12 @@ suites defined in this specification.
 
           <p>
 The `publicKeyMultibase` property represents a Multibase-encoded Multikey
-expression of a Dilithium public key.
-<span class="issue">Specify acceptable Dilithium key sizes</span>
+expression of a ML-DSA public key.
+<span class="issue">Specify acceptable ML-DSA key sizes</span>
           </p>
 
           <p>
-The Multikey encoding of a Dilithium public key MUST start with the two-byte
+The Multikey encoding of a ML-DSA public key MUST start with the two-byte
 prefix `0x8724` (the varint expression of `0x1207`) followed by the 1312-byte
 compressed public key data. The resulting 1314-byte value MUST then be encoded
 using the base-64-url alphabet, according to the
@@ -350,8 +350,9 @@ Multicodec value other than `0x1207` being used in a `publicKeyMultibase` value.
 }
           </pre>
 
+          <span class="issue">Do the examples need updating?</span>
           <pre class="example nohighlight"
-            title="A Dilithium-2 public key encoded as a Multikey">
+            title="A ML-DSA-44 public key encoded as a Multikey">
 {
   "id": "https://example.com/issuer/123#key-0",
   "type": "Multikey",
@@ -369,7 +370,7 @@ Multicodec value other than `0x1207` being used in a `publicKeyMultibase` value.
           </pre>
 
           <pre class="example nohighlight" title="Two public keys (P-256 and
-            Dilithium-2) encoded as Multikeys in a controller document">
+            ml-dsa-44) encoded as Multikeys in a controller document">
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
@@ -412,11 +413,11 @@ Multicodec value other than `0x1207` being used in a `publicKeyMultibase` value.
 
           <p>
 The `secretKeyMultibase` property represents a Multibase-encoded Multikey
-expression of a Dilithium-2 secret key (also sometimes referred to as a
+expression of a ML-DSA secret key (also sometimes referred to as a
 private key).
           </p>
           <p>
-The encoding of a Dilithium=2 secret key MUST start with the two-byte prefix
+The encoding of a <span class="issue">What should this be now we have moved to ML-DSA</span>ML-DSA=44 secret key MUST start with the two-byte prefix
 `0x8726` (the varint expression of `0x1307`) followed by the 2528-byte secret
 key data. The 2530-byte value MUST then be encoded using the base-64-url-nopad
 alphabet, according to
@@ -457,20 +458,20 @@ The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
 The `cryptosuite` property of the proof MUST be
-`experimental-quantum-safe-dilithium-2024`.
+`experimental-ml-dsa-2024`.
           </p>
           <p>
-The value of the `proofValue` property of the proof MUST be an Dilithium-2
+The value of the `proofValue` property of the proof MUST be an ML-DSA-44
 signature produced according to using the algorithms specified in section
 [[[#algorithms]]], encoded according
-to ??? encoded using the base-64-url-nopad header and
+to <span class="issue">What is the encoding?</span>??? encoded using the base-64-url-nopad header and
 alphabet as described in the
 <a href="https://www.w3.org/TR/vc-data-integrity/#multibase-0">
 Multibase section</a> of [[VC-DATA-INTEGRITY]].
           </p>
 
           <pre class="example nohighlight"
-            title="A Dilithium-2 quantum-safe digital signature expressed as a
+            title="A ML-DSA-44 quantum-safe digital signature expressed as a
               DataIntegrityProof">
 {
   "@context": [
@@ -480,7 +481,7 @@ Multibase section</a> of [[VC-DATA-INTEGRITY]].
   "myWebsite": "https://hello.world.example/",
   "proof": {
     "type": "DataIntegrityProof",
-    "cryptosuite": "experimental-quantum-safe-dilithium-2024",
+    "cryptosuite": "experimental-mldsa-2024",
     "created": "2024-04-24T23:36:38Z",
     "verificationMethod": "https://vc.example/issuers/5678#key-3",
     "proofPurpose": "assertionMethod",
@@ -551,7 +552,7 @@ Multibase section</a> of [[VC-DATA-INTEGRITY]].
 
       <p>
 The following section describes multiple Data Integrity cryptographic suites
-that utilize the Dilithium-2 signature algorithm.
+that utilize the ML-DSA-44 signature algorithm.
       </p>
 
       <p>
@@ -564,7 +565,7 @@ functions in this section use information from the verification method
 
       <p>
 When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is used with
-Dilithium-2 algorithms, the cryptographic hashing function that is passed to the
+ML-DSA-44 algorithms, the cryptographic hashing function that is passed to the
 algorithm MUST be SHA-2 with 256 bits of output is utilized.
       </p>
 
@@ -595,15 +596,15 @@ Initialize |cryptosuite| to an empty [=struct=].
 If |options|.|type| does not equal `DataIntegrityProof`, return |cryptosuite|.
           </li>
           <li>
-If |options|.|cryptosuite| is `experimental-dilithium-quantum-safe-2024` then:
+If |options|.|cryptosuite| is `experimental-mldsa-2024` then:
             <ol class="algorithm">
               <li>
 Set |cryptosuite|.|createProof| to the algorithm in Section
-[[[#create-proof-experimental-dilithium-quantum-safe-2024]]].
+[[[#create-proof-experimental-mldsa-2024]]].
               </li>
               <li>
 Set |cryptosuite|.|verifyProof| to the algorithm in Section
-[[[#proof-verification-experimental-dilithium-quantum-safe-2024]]].
+[[[#proof-verification-experimental-mldsa-2024]]].
               </li>
             </ol>
           </li>
@@ -615,10 +616,10 @@ Return |cryptosuite|.
       </section>
 
       <section>
-        <h3>experimental-dilithium-quantum-safe-2024</h3>
+        <h3>experimental-mldsa-2024</h3>
 
         <p>
-The `experimental-dilithium-quantum-safe-2024` cryptographic suite takes an
+The `experimental-mldsa-2024` cryptographic suite takes an
 input document, canonicalizes the document using the Universal RDF Dataset
 Canonicalization Algorithm [[RDF-CANON]], and then cryptographically hashes and
 signs the output resulting in the production of a data integrity proof. The
@@ -627,7 +628,7 @@ integrity proof.
         </p>
 
         <section>
-          <h4>Create Proof (experimental-dilithium-quantum-safe-2024)</h4>
+          <h4>Create Proof (experimental-mldsa-2024)</h4>
 
           <p>
 The following algorithm specifies how to create a [=data integrity proof=] given
@@ -643,22 +644,22 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-experimental-dilithium-quantum-safe-2024]]] with
+Section [[[#proof-configuration-experimental-mldsa-2024]]] with
 |options| passed as a parameter.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-dilithium-quantum-safe-2024"></a> with |unsecuredDocument|,
+href="#transformation-experimental-mldsa-2024"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-dilithium-quantum-safe-2024]]] with |transformedData| and |proofConfig|
+[[[#hashing-experimental-mldsa-2024]]] with |transformedData| and |proofConfig|
 passed as a parameters.
             </li>
             <li>
 Let |proofBytes| be the result of running the algorithm in Section
-[[[#proof-serialization-experimental-dilithium-quantum-safe-2024]]] with |hashData| and
+[[[#proof-serialization-experimental-mldsa-2024]]] with |hashData| and
 |options| passed as parameters.
             </li>
             <li>
@@ -673,7 +674,7 @@ Return |proof| as the [=data integrity proof=].
         </section>
 
         <section>
-          <h4>Verify Proof (experimental-dilithium-quantum-safe-2024)</h4>
+          <h4>Verify Proof (experimental-mldsa-2024)</h4>
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
@@ -708,17 +709,17 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-dilithium-quantum-safe-2024"></a> with |unsecuredDocument| and
+href="#transformation-experimental-mldsa-2024"></a> with |unsecuredDocument| and
 |proofConfig| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-dilithium-quantum-safe-2024]]] with |transformedData| and |proofConfig|
+[[[#hashing-experimental-mldsa-2024]]] with |transformedData| and |proofConfig|
 passed as a parameters.
           </li>
           <li>
 Let |verified:boolean| be the result of running the algorithm in Section
-[[[#proof-verification-experimental-dilithium-quantum-safe-2024]]] algorithm on |hashData|,
+[[[#proof-verification-experimental-mldsa-2024]]] algorithm on |hashData|,
 |proofBytes|, and |proofConfig|.
             </li>
             <li>
@@ -736,12 +737,12 @@ Return a [=verification result=] with [=struct/items=]:
         </section>
 
         <section>
-          <h4>Transformation (experimental-dilithium-quantum-safe-2024)</h4>
+          <h4>Transformation (experimental-mldsa-2024)</h4>
 
           <p>
 The following algorithm specifies how to transform an unsecured input document
 into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section [[[#hashing-experimental-dilithium-quantum-safe-2024]]].
+hashing algorithm in Section [[[#hashing-experimental-mldsa-2024]]].
           </p>
 
           <p>
@@ -761,7 +762,7 @@ encoding.
             <li>
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `experimental-dilithium-quantum-safe-2024` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `experimental-mldsa-2024` then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>
@@ -779,14 +780,14 @@ Return |canonicalDocument| as the <em>transformed data document</em>.
         </section>
 
         <section>
-          <h4>Hashing (experimental-dilithium-quantum-safe-2024)</h4>
+          <h4>Hashing (experimental-mldsa-2024)</h4>
 
           <p>
 The following algorithm specifies how to cryptographically hash a
 <em>transformed data document</em> and <em>proof configuration</em>
 into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section [[[#proof-serialization-experimental-dilithium-quantum-safe-2024]]] or
-Section [[[#proof-verification-experimental-dilithium-quantum-safe-2024]]].
+algorithms in Section [[[#proof-serialization-experimental-mldsa-2024]]] or
+Section [[[#proof-verification-experimental-mldsa-2024]]].
           </p>
 
           <p>
@@ -824,12 +825,12 @@ Return |hashData| as the <em>hash data</em>.
         </section>
 
         <section>
-          <h4>Proof Configuration (experimental-dilithium-quantum-safe-2024)</h4>
+          <h4>Proof Configuration (experimental-mldsa-2024)</h4>
 
           <p>
 The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-experimental-dilithium-quantum-safe-2024">proof hashing algorithm</a>.
+that is used as input to the <a href="#hashing-experimental-mldsa-2024">proof hashing algorithm</a>.
           </p>
 
           <p>
@@ -848,7 +849,7 @@ Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `experimental-dilithium-quantum-safe-2024`, an
+|proofConfig|.|cryptosuite| is not set to `experimental-mldsa-2024`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>
@@ -872,7 +873,7 @@ Return |canonicalProofConfig|.
         </section>
 
         <section>
-          <h4>Proof Serialization (experimental-dilithium-quantum-safe-2024)</h4>
+          <h4>Proof Serialization (experimental-mldsa-2024)</h4>
 
           <p>
 The following algorithm specifies how to serialize a digital signature from
@@ -898,7 +899,7 @@ bytes) associated with the verification method identified by the
 |options|.|verificationMethod| value.
             </li>
             <li>
-Let |proofBytes| be the result of applying the Dilithium-2
+Let |proofBytes| be the result of applying the ML_DSA_44
 Signature Algorithm [???REF???], with |hashData| as the data
 to be signed using the private key specified by |privateKeyBytes|.
 |proofBytes| will be exactly 2420 bytes in size.
@@ -911,7 +912,7 @@ Return |proofBytes| as the <em>digital proof</em>.
         </section>
 
         <section>
-          <h4>Proof Verification (experimental-dilithium-quantum-safe-2024)</h4>
+          <h4>Proof Verification (experimental-mldsa-2024)</h4>
 
           <p>
 The following algorithm specifies how to verify a digital signature from
@@ -937,7 +938,7 @@ Section 4: Retrieve Verification Method</a>.
             </li>
             <li>
 Let |verificationResult| be the result of applying the verification
-algorithm Dilithium-2 Digital Signature Algorithm [???REF???],
+algorithm ML-DSA-44 Digital Signature Algorithm [???REF???],
 with |hashData| as the data to be verified against the
 |proofBytes| using the public key specified by
 |publicKeyBytes|.

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@ the Data Integrity [[VC-DATA-INTEGRITY]] specification.
 This specification uses either the RDF Dataset Canonicalization Algorithm
 [[RDF-CANON]] or the JSON Canonicalization Scheme [[RFC8785]] to transform the
 input document into its canonical form. It uses SHA-256 [[RFC6234]] as the
-message digest algorithm and ml-dsa-44 as the signature algorithm.
+message digest algorithm and ML-DSA-44 as the signature algorithm.
       </p>
 
       <section id="terminology">

--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@ Multicodec value other than `0x1207` being used in a `publicKeyMultibase` value.
           </pre>
 
           <pre class="example nohighlight" title="Two public keys (P-256 and
-            ml-dsa-44) encoded as Multikeys in a controller document">
+            ML-DSA-44) encoded as Multikeys in a controller document">
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",

--- a/index.html
+++ b/index.html
@@ -328,7 +328,6 @@ suites defined in this specification.
           <p>
 The `publicKeyMultibase` property represents a Multibase-encoded Multikey
 expression of a ML-DSA public key.
-<span class="issue">Specify acceptable ML-DSA key sizes</span>
           </p>
 
           <p>
@@ -488,7 +487,7 @@ Multibase section</a> of [[VC-DATA-INTEGRITY]].
   "myWebsite": "https://hello.world.example/",
   "proof": {
     "type": "DataIntegrityProof",
-    "cryptosuite": "experimental-mldsa-2024",
+    "cryptosuite": "experimental-mldsa44-2024",
     "created": "2024-04-24T23:36:38Z",
     "verificationMethod": "https://vc.example/issuers/5678#key-3",
     "proofPurpose": "assertionMethod",
@@ -603,15 +602,15 @@ Initialize |cryptosuite| to an empty [=struct=].
 If |options|.|type| does not equal `DataIntegrityProof`, return |cryptosuite|.
           </li>
           <li>
-If |options|.|cryptosuite| is `experimental-mldsa-2024` then:
+If |options|.|cryptosuite| is `experimental-mldsa44-2024` then:
             <ol class="algorithm">
               <li>
 Set |cryptosuite|.|createProof| to the algorithm in Section
-[[[#create-proof-experimental-mldsa-2024]]].
+[[[#create-proof-experimental-mldsa44-2024]]].
               </li>
               <li>
 Set |cryptosuite|.|verifyProof| to the algorithm in Section
-[[[#proof-verification-experimental-mldsa-2024]]].
+[[[#proof-verification-experimental-mldsa44-2024]]].
               </li>
             </ol>
           </li>
@@ -623,10 +622,10 @@ Return |cryptosuite|.
       </section>
 
       <section>
-        <h3>experimental-mldsa-2024</h3>
+        <h3>experimental-mldsa44-2024</h3>
 
         <p>
-The `experimental-mldsa-2024` cryptographic suite takes an
+The `experimental-mldsa44-2024` cryptographic suite takes an
 input document, canonicalizes the document using the Universal RDF Dataset
 Canonicalization Algorithm [[RDF-CANON]], and then cryptographically hashes and
 signs the output resulting in the production of a data integrity proof. The
@@ -635,7 +634,7 @@ integrity proof.
         </p>
 
         <section>
-          <h4>Create Proof (experimental-mldsa-2024)</h4>
+          <h4>Create Proof (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to create a [=data integrity proof=] given
@@ -651,22 +650,22 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-experimental-mldsa-2024]]] with
+Section [[[#proof-configuration-experimental-mldsa44-2024]]] with
 |options| passed as a parameter.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-mldsa-2024"></a> with |unsecuredDocument|,
+href="#transformation-experimental-mldsa44-2024"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-mldsa-2024]]] with |transformedData| and |proofConfig|
+[[[#hashing-experimental-mldsa44-2024]]] with |transformedData| and |proofConfig|
 passed as a parameters.
             </li>
             <li>
 Let |proofBytes| be the result of running the algorithm in Section
-[[[#proof-serialization-experimental-mldsa-2024]]] with |hashData| and
+[[[#proof-serialization-experimental-mldsa44-2024]]] with |hashData| and
 |options| passed as parameters.
             </li>
             <li>
@@ -681,7 +680,7 @@ Return |proof| as the [=data integrity proof=].
         </section>
 
         <section>
-          <h4>Verify Proof (experimental-mldsa-2024)</h4>
+          <h4>Verify Proof (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
@@ -716,17 +715,17 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-mldsa-2024"></a> with |unsecuredDocument| and
+href="#transformation-experimental-mldsa44-2024"></a> with |unsecuredDocument| and
 |proofConfig| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-mldsa-2024]]] with |transformedData| and |proofConfig|
+[[[#hashing-experimental-mldsa44-2024]]] with |transformedData| and |proofConfig|
 passed as a parameters.
           </li>
           <li>
 Let |verified:boolean| be the result of running the algorithm in Section
-[[[#proof-verification-experimental-mldsa-2024]]] algorithm on |hashData|,
+[[[#proof-verification-experimental-mldsa44-2024]]] algorithm on |hashData|,
 |proofBytes|, and |proofConfig|.
             </li>
             <li>
@@ -744,12 +743,12 @@ Return a [=verification result=] with [=struct/items=]:
         </section>
 
         <section>
-          <h4>Transformation (experimental-mldsa-2024)</h4>
+          <h4>Transformation (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to transform an unsecured input document
 into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section [[[#hashing-experimental-mldsa-2024]]].
+hashing algorithm in Section [[[#hashing-experimental-mldsa44-2024]]].
           </p>
 
           <p>
@@ -769,7 +768,7 @@ encoding.
             <li>
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `experimental-mldsa-2024` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `experimental-mldsa44-2024` then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>
@@ -787,14 +786,14 @@ Return |canonicalDocument| as the <em>transformed data document</em>.
         </section>
 
         <section>
-          <h4>Hashing (experimental-mldsa-2024)</h4>
+          <h4>Hashing (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to cryptographically hash a
 <em>transformed data document</em> and <em>proof configuration</em>
 into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section [[[#proof-serialization-experimental-mldsa-2024]]] or
-Section [[[#proof-verification-experimental-mldsa-2024]]].
+algorithms in Section [[[#proof-serialization-experimental-mldsa44-2024]]] or
+Section [[[#proof-verification-experimental-mldsa44-2024]]].
           </p>
 
           <p>
@@ -832,12 +831,12 @@ Return |hashData| as the <em>hash data</em>.
         </section>
 
         <section>
-          <h4>Proof Configuration (experimental-mldsa-2024)</h4>
+          <h4>Proof Configuration (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-experimental-mldsa-2024">proof hashing algorithm</a>.
+that is used as input to the <a href="#hashing-experimental-mldsa44-2024">proof hashing algorithm</a>.
           </p>
 
           <p>
@@ -856,7 +855,7 @@ Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `experimental-mldsa-2024`, an
+|proofConfig|.|cryptosuite| is not set to `experimental-mldsa44-2024`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>
@@ -880,7 +879,7 @@ Return |canonicalProofConfig|.
         </section>
 
         <section>
-          <h4>Proof Serialization (experimental-mldsa-2024)</h4>
+          <h4>Proof Serialization (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to serialize a digital signature from
@@ -919,7 +918,7 @@ Return |proofBytes| as the <em>digital proof</em>.
         </section>
 
         <section>
-          <h4>Proof Verification (experimental-mldsa-2024)</h4>
+          <h4>Proof Verification (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to verify a digital signature from

--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@ expression of a ML-DSA secret key (also sometimes referred to as a
 private key).
           </p>
           <p>
-The encoding of a <span class="issue">What should this be now we have moved to ML-DSA</span>ML-DSA=44 secret key MUST start with the two-byte prefix
+The encoding of a ML-DSA-44 secret key MUST start with the two-byte prefix
 `0x8726` (the varint expression of `0x1307`) followed by the 2528-byte secret
 key data. The 2530-byte value MUST then be encoded using the base-64-url-nopad
 alphabet, according to


### PR DESCRIPTION
I have removed all references to dilithium. Using ML-DSA-44 or experimental-mldsa-2024 where appropriate.

I am not sure what this means for the current examples, I assume they would have to change.

I also attempted to add a reference to the FIPS paper, which I think specifies this ML-DSA algorithm. But I definitely didn't do this correctly.

It is a start :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/di-quantum-safe/pull/1.html" title="Last updated on May 30, 2024, 6:25 PM UTC (1f4ce06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/di-quantum-safe/1/473e33b...wip-abramson:1f4ce06.html" title="Last updated on May 30, 2024, 6:25 PM UTC (1f4ce06)">Diff</a>