### PR TITLE
WIP: Add new quantum safe algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,7 +520,7 @@ The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
 The `cryptosuite` property of the proof MUST be on of the following
-`experimental-mldsa-2024`, `experimental-shs-2025`, `experimental-falcon-2025` 
+`experimental-mldsa44-2024`, `experimental-shs-2025`, `experimental-falcon-2025` 
 or `experimental-sqi-2025`.
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -189,6 +189,13 @@
             // date: "August 2024",
             // publisher: "",
             href: "https://sqisign.org/"
+          },
+          "FIPS-204": {
+            title: "Module-Lattice-Based Digital Signature Standard",
+            authors: [],
+            date: "August 2023",
+            publisher: "Federal Information Processing Standards",
+            href: "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.ipd.pdf"
           }
         },
         xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY"],
@@ -330,11 +337,7 @@ data integrity proofs, such as digital signatures.
         <p>
 These verification methods are used to verify Data Integrity Proofs
 [[VC-DATA-INTEGRITY]] produced using ML-DSA-44 cryptographic key material
-<<<<<<< HEAD
-that is compliant with <span class="issue">cite ML-DSA spec</span>.
-=======
 that is compliant with [[FIPS-204]].
->>>>>>> 70c8a32 (fix refs to FIPS)
 The encoding formats for these key types are provided in this section. Lossless
 cryptographic key transformation processes that result in equivalent
 cryptographic key material MAY be used during the processing of digital

--- a/index.html
+++ b/index.html
@@ -999,7 +999,7 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |options| and 
+href="#transformation"></a> with |unsecuredDocument|, |options|, and 
 `experimental-shs-2025` passed as parameters.
             </li>
             <li>
@@ -1141,7 +1141,7 @@ in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
 Section 4: Algorithms</a>. Required inputs are
 cryptographic hash data (|hashData|),
-a digital signature (|proofBytes|) and
+a digital signature (|proofBytes|), and
 proof options (|options|). A <em>verification result</em>
 represented as a boolean value is produced as output.
           </p>
@@ -1205,7 +1205,7 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |options| and 
+href="#transformation"></a> with |unsecuredDocument|, |options|, and 
 `experimental-falcon-2025` passed as parameters.
             </li>
             <li>
@@ -1234,7 +1234,7 @@ Return |proof| as the [=data integrity proof=].
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
-an <a>secured data document</a>. Required inputs are an
+an <a>secured data document</a>. Required input is a
 <a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
 a <dfn>verification result</dfn>, which is a [=struct=] whose
 [=struct/items=] are:
@@ -1265,7 +1265,7 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |proofOptions|
+href="#transformation"></a> with |unsecuredDocument|, |proofOptions|,
 and `experimental-falcon-2025` passed as parameters.
           </li>
           <li>
@@ -1290,7 +1290,7 @@ Return a [=verification result=] with [=struct/items=]:
                 <dd>|verified|</dd>
                 <dt>[=verifiedDocument=]</dt>
                 <dd>
-|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+|unsecuredDocument| if |verified| is `true`; otherwise, <a data-cite="INFRA#nulls">Null</a></dd>
               </dl>
             </li>
           </ol>
@@ -1347,7 +1347,7 @@ in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
 Section 4: Algorithms</a>. Required inputs are
 cryptographic hash data (|hashData|),
-a digital signature (|proofBytes|) and
+a digital signature (|proofBytes|), and
 proof options (|options|). A <em>verification result</em>
 represented as a boolean value is produced as output.
           </p>
@@ -1411,7 +1411,7 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |options| and 
+href="#transformation"></a> with |unsecuredDocument|, |options|, and
 `experimental-sqi-2025` passed as parameters.
             </li>
             <li>
@@ -1440,7 +1440,7 @@ Return |proof| as the [=data integrity proof=].
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
-an <a>secured data document</a>. Required inputs are an
+an <a>secured data document</a>. Required input is a
 <a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
 a <dfn>verification result</dfn>, which is a [=struct=] whose
 [=struct/items=] are:
@@ -1471,7 +1471,7 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |proofOptions| and 
+href="#transformation"></a> with |unsecuredDocument|, |proofOptions|, and
 `experimental-sqi-2025` passed as parameters.
           </li>
           <li>
@@ -1555,7 +1555,7 @@ in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
 Section 4: Algorithms</a>. Required inputs are
 cryptographic hash data (|hashData|),
-a digital signature (|proofBytes|) and
+a digital signature (|proofBytes|), and
 proof options (|options|). A <em>verification result</em>
 represented as a boolean value is produced as output.
           </p>
@@ -1598,7 +1598,7 @@ hashing algorithm in Section [[[#hashing]]].
 Required inputs to this algorithm are an
 <a data-cite="vc-data-integrity#dfn-unsecured-data-document">
 unsecured data document</a> (|unsecuredDocument|),
-transformation options (|options|) and a cryptosuite identifier (|cryptosuite|). The
+transformation options (|options|), and a cryptosuite identifier (|cryptosuite|). The
 transformation options MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and a cryptosuite
@@ -1610,7 +1610,7 @@ encoding.
           <ol class="algorithm">
             <li>
 If |options|.|type| is not set to the string
-`DataIntegrityProof` and |options|.|cryptosuite| is not
+`DataIntegrityProof` and/or |options|.|cryptosuite| is not
 set to the <em>cryptosuite</em> value then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
@@ -1684,7 +1684,8 @@ that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
 
           <p>
 The required inputs to this algorithm are <em>proof options</em>
-(|options|) and a <em>cryptosuite identifier</em> (|cryptosuite|). The <em>proof options</em> MUST contain a type identifier
+(|options|) and a <em>cryptosuite identifier</em> (|cryptosuite|). The
+<em>proof options</em> MUST contain a type identifier
 for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and MUST contain the cryptosuite

--- a/index.html
+++ b/index.html
@@ -330,7 +330,11 @@ data integrity proofs, such as digital signatures.
         <p>
 These verification methods are used to verify Data Integrity Proofs
 [[VC-DATA-INTEGRITY]] produced using ML-DSA-44 cryptographic key material
+<<<<<<< HEAD
 that is compliant with <span class="issue">cite ML-DSA spec</span>.
+=======
+that is compliant with [[FIPS-204]].
+>>>>>>> 70c8a32 (fix refs to FIPS)
 The encoding formats for these key types are provided in this section. Lossless
 cryptographic key transformation processes that result in equivalent
 cryptographic key material MAY be used during the processing of digital

--- a/index.html
+++ b/index.html
@@ -351,10 +351,42 @@ The `publicKeyMultibase` property represents a Multibase-encoded Multikey
 expression of a ML-DSA public key.
           </p>
 
+
+
           <p>
 The Multikey encoding of a ML-DSA public key MUST start with the two-byte
 prefix `0x8724` (the varint expression of `0x1207`) followed by the 1312-byte
 compressed public key data. The resulting 1314-byte value MUST then be encoded
+using the base-64-url alphabet, according to the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase</a> section in the
+[[VC-DATA-INTEGRITY]] specification, and then prepended with the base-64-url
+Multibase header (`u`).
+          </p>
+
+          <p>
+The Multikey encoding of a SHS-DSA public key MUST start with the two-byte
+prefix `????` (the varint expression of `????`) followed by the 7856-byte
+compressed public key data [[FIPS-205]]. The resulting 7858-byte value MUST then be encoded
+using the base-64-url alphabet, according to the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase</a> section in the
+[[VC-DATA-INTEGRITY]] specification, and then prepended with the base-64-url
+Multibase header (`u`).
+          </p>
+
+          <p>
+The Multikey encoding of a Falcon public key MUST start with the two-byte
+prefix `????` (the varint expression of `????`) followed by the 897-byte
+compressed public key data [[FALCON]]. The resulting 899-byte value MUST then be encoded
+using the base-64-url alphabet, according to the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase</a> section in the
+[[VC-DATA-INTEGRITY]] specification, and then prepended with the base-64-url
+Multibase header (`u`).
+          </p>
+
+          <p>
+The Multikey encoding of a SQISign public key MUST start with the two-byte
+prefix `????` (the varint expression of `????`) followed by the 65-byte
+compressed public key data [[SQISIGN]]. The resulting 67-byte value MUST then be encoded
 using the base-64-url alphabet, according to the
 <a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase</a> section in the
 [[VC-DATA-INTEGRITY]] specification, and then prepended with the base-64-url
@@ -367,15 +399,7 @@ key. Implementations of this specification will raise errors in the event of a
 Multicodec value other than `0x1207` being used in a `publicKeyMultibase` value.
           </p>
 
-          <pre class="example nohighlight"
-            title="An P-256 public key encoded as a Multikey">
-{
-  "id": "https://example.com/issuer/123#key-0",
-  "type": "Multikey",
-  "controller": "https://example.com/issuer/123",
-  "publicKeyMultibase": "u"
-}
-          </pre>
+
 
           <span class="issue">Do the examples need updating?</span>
           <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -165,9 +165,30 @@
           "FIPS-204": {
             title: "Module-Lattice-Based Digital Signature Standard",
             authors: [],
-            date: "August 2023",
+            date: "August 2024",
             publisher: "Federal Information Processing Standards",
-            href: "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.ipd.pdf"
+            href: "https://csrc.nist.gov/pubs/fips/204/final"
+          },
+          "FIPS-205": {
+            title: "Stateless Hash-Based Digital Signature Standard",
+            authors: [],
+            date: "August 2024",
+            publisher: "Federal Information Processing Standards",
+            href: "https://csrc.nist.gov/pubs/fips/205/final"
+          },
+          "FALCON": {
+            title: "Fast-Fourier Lattice-based Compact Signatures over NTRU",
+            authors: [],
+            // date: "August 2024",
+            // publisher: "",
+            href: "https://falcon-sign.info/"
+          },
+          "SQISIGN": {
+            title: "SQI Sign",
+            authors: [],
+            // date: "August 2024",
+            // publisher: "",
+            href: "https://sqisign.org/"
           }
         },
         xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY"],
@@ -711,8 +732,8 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|,
-|proofConfig|, and |options| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|, |options| and 
+`experimental-mldsa44-2024` passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
@@ -761,7 +782,7 @@ Let |unsecuredDocument| be a copy of |securedDocument| with
 the `proof` value removed.
           </li>
           <li>
-Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+Let |proofOptions| be a copy of |securedDocument|.|proof| with `proofValue`
 removed.
           </li>
           <li>
@@ -771,8 +792,13 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument| and
-|proofConfig| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|,
+|proofOptions| and `experimental-mldsa44-2024` passed as parameters.
+          </li>
+          <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration]]] with |options| and 
+`experimental-mldsa44-2024` passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
@@ -910,8 +936,8 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|,
-|proofConfig|, and |options| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|, |options| and 
+`experimental-shs-2025` passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
@@ -960,7 +986,7 @@ Let |unsecuredDocument| be a copy of |securedDocument| with
 the `proof` value removed.
           </li>
           <li>
-Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+Let |proofOptions| be a copy of |securedDocument|.|proof| with `proofValue`
 removed.
           </li>
           <li>
@@ -970,9 +996,14 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument| and
-|proofConfig| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|,
+|proofOptions| and `experimental-shs-2025` passed as parameters.
           </li>
+          <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration]]] with
+|options| and `experimental-shs-2025` passed as parameters.
+          </li>          
           <li>
 Let |hashData| be the result of running the algorithm in Section
 [[[#hashing]]] with |transformedData| and |proofConfig|
@@ -1025,9 +1056,9 @@ bytes) associated with the verification method identified by the
             </li>
             <li>
 Let |proofBytes| be the result of applying the Stateless Hash-Based Signature (SHS)
-Algorithm [[TODO SHS PAPER]], with |hashData| as the data
+Algorithm [[FIPS-205]], with |hashData| as the data
 to be signed using the private key specified by |privateKeyBytes|.
-|proofBytes| will be exactly ??? bytes in size.
+|proofBytes| will be exactly 7856 bytes in size.
             </li>
             <li>
 Return |proofBytes| as the <em>digital proof</em>.
@@ -1064,7 +1095,7 @@ Section 4: Retrieve Verification Method</a>.
             <li>
 Let |verificationResult| be the result of applying the verification
 algorithm for the Stateless Hash-Based Signature (SHS)
-scheme [[TODO SHS PAPER]],
+scheme [[FIPS-205]],
 with |hashData| as the data to be verified against the
 |proofBytes| using the public key specified by
 |publicKeyBytes|.
@@ -1111,8 +1142,8 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|,
-|proofConfig|, and |options| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|, |options| and 
+`experimental-falcon-2025` passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
@@ -1161,7 +1192,7 @@ Let |unsecuredDocument| be a copy of |securedDocument| with
 the `proof` value removed.
           </li>
           <li>
-Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+Let |proofOptions| be a copy of |securedDocument|.|proof| with `proofValue`
 removed.
           </li>
           <li>
@@ -1171,8 +1202,13 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument| and
-|proofConfig| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|, |proofOptions|
+and `experimental-falcon-2025` passed as parameters.
+          </li>
+          <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration]]] with
+|options| and `experimental-falcon-2025` passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
@@ -1226,9 +1262,9 @@ bytes) associated with the verification method identified by the
             </li>
             <li>
 Let |proofBytes| be the result of applying the Falcon
-Signature Algorithm [[TODO FALCON PAPER]], with |hashData| as the data
+Signature Algorithm [[FALCON]], with |hashData| as the data
 to be signed using the private key specified by |privateKeyBytes|.
-|proofBytes| will be exactly ??? bytes in size.
+|proofBytes| will be exactly 666 bytes in size.
             </li>
             <li>
 Return |proofBytes| as the <em>digital proof</em>.
@@ -1264,7 +1300,7 @@ Section 4: Retrieve Verification Method</a>.
             </li>
             <li>
 Let |verificationResult| be the result of applying the verification
-algorithm from the Falcon Digital Signature scheme [[TODO Falcon Paper]],
+algorithm from the Falcon Digital Signature scheme [[FALCON]],
 with |hashData| as the data to be verified against the
 |proofBytes| using the public key specified by
 |publicKeyBytes|.
@@ -1312,8 +1348,8 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|,
-|proofConfig|, and |options| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|, |options| and 
+`experimental-sqi-2025` passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
@@ -1362,7 +1398,7 @@ Let |unsecuredDocument| be a copy of |securedDocument| with
 the `proof` value removed.
           </li>
           <li>
-Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+Let |proofOptions| be a copy of |securedDocument|.|proof| with `proofValue`
 removed.
           </li>
           <li>
@@ -1372,8 +1408,13 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument| and
-|proofConfig| passed as parameters.
+href="#transformation"></a> with |unsecuredDocument|, |proofOptions| and 
+`experimental-sqi-2025` passed as parameters.
+          </li>
+          <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration]]] with
+|options| and `experimental-sqi-2025` passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
@@ -1429,9 +1470,9 @@ bytes) associated with the verification method identified by the
             </li>
             <li>
 Let |proofBytes| be the result of applying the SQISign
-Signature Algorithm [[TODO: SQI Paper]], with |hashData| as the data
+Signature Algorithm [[SQISIGN]], with |hashData| as the data
 to be signed using the private key specified by |privateKeyBytes|.
-|proofBytes| will be exactly ??? bytes in size.
+|proofBytes| will be exactly 148 bytes in size.
             </li>
             <li>
 Return |proofBytes| as the <em>digital proof</em>.
@@ -1467,7 +1508,7 @@ Section 4: Retrieve Verification Method</a>.
             </li>
             <li>
 Let |verificationResult| be the result of applying the verification
-algorithm for the SQISign Algorithm [[TODO: SQI Paper]],
+algorithm for the SQISign Algorithm [[SQISIGN]],
 with |hashData| as the data to be verified against the
 |proofBytes| using the public key specified by
 |publicKeyBytes|.
@@ -1493,8 +1534,8 @@ hashing algorithm in Section [[[#hashing]]].
           <p>
 Required inputs to this algorithm are an
 <a data-cite="vc-data-integrity#dfn-unsecured-data-document">
-unsecured data document</a> (|unsecuredDocument|) and
-transformation options (|options|). The
+unsecured data document</a> (|unsecuredDocument|),
+transformation options (|options|) and a cryptosuite identifier (|cryptosuite|). The
 transformation options MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and a cryptosuite
@@ -1507,7 +1548,7 @@ encoding.
             <li>
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `experimental-sqi-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the <em>cryptosuite</em> value then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>
@@ -1594,7 +1635,7 @@ Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `cryptosuite`, an
+|proofConfig|.|cryptosuite| is not set to the <em>cryptosuite</em>, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -661,7 +661,7 @@ Set |cryptosuite|.|verifyProof| to the algorithm in Section
             </ol>
           </li>
           <li>
-If |options|.|cryptosuite| is `experimental-mldsa44-2024` then:
+If |options|.|cryptosuite| is `experimental-mldsa-2024` then:
             <ol class="algorithm">
               <li>
 Set |cryptosuite|.|createProof| to the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -547,8 +547,8 @@ of [[VC-DATA-INTEGRITY]] with the following restrictions.
 The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
-The `cryptosuite` property of the proof MUST be on of the following
-`experimental-mldsa44-2024`, `experimental-shs-2025`, `experimental-falcon-2025` 
+The `cryptosuite` property of the proof MUST be one of the following
+`experimental-mldsa44-2024`, `experimental-shs-2025`, `experimental-falcon-2025`,
 or `experimental-sqi-2025`.
           </p>
           <p>
@@ -703,7 +703,7 @@ Set |cryptosuite|.|verifyProof| to the algorithm in Section
 If |options|.|cryptosuite| is `experimental-mldsa-2024` then:
             <ol class="algorithm">
               <li>
-Set |cryptosuite|.|createProof| to the algorithm in Section
+Set |cryptosuite|.|createProof| to the result of running the algorithm in Section
 [[[#create-proof-experimental-mldsa44-2024]]].
               </li>
               <li>
@@ -795,7 +795,7 @@ Section [[[#proof-configuration]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |options| and 
+href="#transformation"></a> with |unsecuredDocument|, |options|, and 
 `experimental-mldsa44-2024` passed as parameters.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -463,8 +463,9 @@ of [[VC-DATA-INTEGRITY]] with the following restrictions.
 The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
-The `cryptosuite` property of the proof MUST be
-`experimental-ml-dsa-2024`.
+The `cryptosuite` property of the proof MUST be on of the following
+`experimental-mldsa-2024`, `experimental-shs-2025`, `experimental-falcon-2025` 
+or `experimental-sqi-2025`.
           </p>
           <p>
 The value of the `proofValue` property of the proof MUST be an ML-DSA-44
@@ -611,6 +612,61 @@ Set |cryptosuite|.|createProof| to the algorithm in Section
               <li>
 Set |cryptosuite|.|verifyProof| to the algorithm in Section
 [[[#proof-verification-experimental-mldsa44-2024]]].
+              </li>
+            </ol>
+          </li>
+          <li>
+If |options|.|cryptosuite| is `experimental-mldsa44-2024` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|createProof| to the algorithm in Section
+[[[#create-proof-experimental-mldsa44-2024]]].
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+[[[#proof-verification-experimental-mldsa44-2024]]].
+              </li>
+            </ol>
+          </li>
+          <li>
+            <li>
+              If |options|.|cryptosuite| is `experimental-shs-2025` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|createProof| to the algorithm in Section
+[[[#create-proof-experimental-shs-2025]]].
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+[[[#proof-verification-experimental-shs-2025]]].
+              </li>
+            </ol>
+          </li>
+          <li>
+            <li>
+              If |options|.|cryptosuite| is `experimental-falcon-2025` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|createProof| to the algorithm in Section
+[[[#create-proof-experimental-falcon-2025]]].
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+[[[#proof-verification-experimental-falcon-2025]]].
+              </li>
+            </ol>
+          </li>
+          <li>
+            <li>
+              If |options|.|cryptosuite| is `experimental-sqi-2025` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|createProof| to the algorithm in Section
+[[[#create-proof-experimental-sqi-2025]]].
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+[[[#proof-verification-experimental-sqi-2025]]].
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -672,7 +672,7 @@ Set |cryptosuite|.|verifyProof| to the algorithm in Section
             </ol>
           </li>
           <li>
-If |options|.|cryptosuite| is `experimental-mldsa-2024` then:
+If |options|.|cryptosuite| is `experimental-mldsa44-2024` then:
             <ol class="algorithm">
               <li>
 Set |cryptosuite|.|createProof| to the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@ data integrity proofs, such as digital signatures.
         <p>
 These verification methods are used to verify Data Integrity Proofs
 [[VC-DATA-INTEGRITY]] produced using ML-DSA-44 cryptographic key material
-that is compliant with [[FIPS-204]].
+that is compliant with <span class="issue">cite ML-DSA spec</span>.
 The encoding formats for these key types are provided in this section. Lossless
 cryptographic key transformation processes that result in equivalent
 cryptographic key material MAY be used during the processing of digital

--- a/index.html
+++ b/index.html
@@ -700,7 +700,7 @@ Set |cryptosuite|.|verifyProof| to the algorithm in Section
             </ol>
           </li>
           <li>
-If |options|.|cryptosuite| is `experimental-mldsa44-2024` then:
+If |options|.|cryptosuite| is `experimental-mldsa-2024` then:
             <ol class="algorithm">
               <li>
 Set |cryptosuite|.|createProof| to the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -193,9 +193,30 @@
           "FIPS-204": {
             title: "Module-Lattice-Based Digital Signature Standard",
             authors: [],
-            date: "August 2023",
+            date: "August 2024",
             publisher: "Federal Information Processing Standards",
-            href: "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.ipd.pdf"
+            href: "https://csrc.nist.gov/pubs/fips/204/final"
+          },
+          "FIPS-205": {
+            title: "Stateless Hash-Based Digital Signature Standard",
+            authors: [],
+            date: "August 2024",
+            publisher: "Federal Information Processing Standards",
+            href: "https://csrc.nist.gov/pubs/fips/205/final"
+          },
+          "FALCON": {
+            title: "Fast-Fourier Lattice-based Compact Signatures over NTRU",
+            authors: [],
+            // date: "August 2024",
+            // publisher: "",
+            href: "https://falcon-sign.info/"
+          },
+          "SQISIGN": {
+            title: "SQI Sign",
+            authors: [],
+            // date: "August 2024",
+            // publisher: "",
+            href: "https://sqisign.org/"
           }
         },
         xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY"],

--- a/index.html
+++ b/index.html
@@ -655,12 +655,12 @@ Section [[[#proof-configuration-experimental-mldsa44-2024]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-mldsa44-2024"></a> with |unsecuredDocument|,
+href="#transformation"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-mldsa44-2024]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
             </li>
             <li>
@@ -715,12 +715,12 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-mldsa44-2024"></a> with |unsecuredDocument| and
+href="#transformation"></a> with |unsecuredDocument| and
 |proofConfig| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-mldsa44-2024]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
           </li>
           <li>
@@ -742,101 +742,14 @@ Return a [=verification result=] with [=struct/items=]:
 
         </section>
 
-        <section>
-          <h4>Transformation (experimental-mldsa44-2024)</h4>
-
-          <p>
-The following algorithm specifies how to transform an unsecured input document
-into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section [[[#hashing-experimental-mldsa44-2024]]].
-          </p>
-
-          <p>
-Required inputs to this algorithm are an
-<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
-unsecured data document</a> (|unsecuredDocument|) and
-transformation options (|options|). The
-transformation options MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and a cryptosuite
-identifier (|cryptosuite|). A <em>transformed data document</em> is
-produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
-encoding.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-If |options|.|type| is not set to the string
-`DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `experimental-mldsa44-2024` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
-            </li>
-            <li>
-Let |canonicalDocument| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |unsecuredDocument|.
-            </li>
-            <li>
-Set |output| to the value of |canonicalDocument|.
-            </li>
-            <li>
-Return |canonicalDocument| as the <em>transformed data document</em>.
-            </li>
-          </ol>
-        </section>
-
-        <section>
-          <h4>Hashing (experimental-mldsa44-2024)</h4>
-
-          <p>
-The following algorithm specifies how to cryptographically hash a
-<em>transformed data document</em> and <em>proof configuration</em>
-into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section [[[#proof-serialization-experimental-mldsa44-2024]]] or
-Section [[[#proof-verification-experimental-mldsa44-2024]]].
-          </p>
-
-          <p>
-The required inputs to this algorithm are a <em>transformed data document</em>
-(|transformedDocument|) and <em>canonical proof configuration</em>
-(|canonicalProofConfig|). A single <em>hash data</em> value represented as
-series of bytes is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |transformedDocumentHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-respective |transformedDocument|.
-Respective |transformedDocumentHash| will be exactly 32 bytes
-in size.
-            </li>
-            <li>
-Let |proofConfigHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-|canonicalProofConfig|. Respective |proofConfigHash|
-will be exactly 32 bytes in size.
-            </li>
-            <li>
-Let |hashData| be the result of joining |proofConfigHash| (the
-first hash) with |transformedDocumentHash| (the second hash).
-            </li>
-            <li>
-Return |hashData| as the <em>hash data</em>.
-            </li>
-          </ol>
-
-        </section>
-
+        
         <section>
           <h4>Proof Configuration (experimental-mldsa44-2024)</h4>
 
           <p>
 The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-experimental-mldsa44-2024">proof hashing algorithm</a>.
+that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
           </p>
 
           <p>
@@ -990,12 +903,12 @@ Section [[[#proof-configuration-experimental-shs-2025]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-shs-2025"></a> with |unsecuredDocument|,
+href="#transformation"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-shs-2025]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
             </li>
             <li>
@@ -1050,12 +963,12 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-shs-2025"></a> with |unsecuredDocument| and
+href="#transformation"></a> with |unsecuredDocument| and
 |proofConfig| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-shs-2025]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
           </li>
           <li>
@@ -1077,101 +990,14 @@ Return a [=verification result=] with [=struct/items=]:
 
         </section>
 
-        <section>
-          <h4>Transformation (experimental-shs-2025)</h4>
-
-          <p>
-The following algorithm specifies how to transform an unsecured input document
-into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section [[[#hashing-experimental-shs-2025]]].
-          </p>
-
-          <p>
-Required inputs to this algorithm are an
-<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
-unsecured data document</a> (|unsecuredDocument|) and
-transformation options (|options|). The
-transformation options MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and a cryptosuite
-identifier (|cryptosuite|). A <em>transformed data document</em> is
-produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
-encoding.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-If |options|.|type| is not set to the string
-`DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `experimental-shs-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
-            </li>
-            <li>
-Let |canonicalDocument| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |unsecuredDocument|.
-            </li>
-            <li>
-Set |output| to the value of |canonicalDocument|.
-            </li>
-            <li>
-Return |canonicalDocument| as the <em>transformed data document</em>.
-            </li>
-          </ol>
-        </section>
-
-        <section>
-          <h4>Hashing (experimental-shs-2025)</h4>
-
-          <p>
-The following algorithm specifies how to cryptographically hash a
-<em>transformed data document</em> and <em>proof configuration</em>
-into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section [[[#proof-serialization-experimental-shs-2025]]] or
-Section [[[#proof-verification-experimental-shs-2025]]].
-          </p>
-
-          <p>
-The required inputs to this algorithm are a <em>transformed data document</em>
-(|transformedDocument|) and <em>canonical proof configuration</em>
-(|canonicalProofConfig|). A single <em>hash data</em> value represented as
-series of bytes is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |transformedDocumentHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-respective |transformedDocument|.
-Respective |transformedDocumentHash| will be exactly 32 bytes
-in size.
-            </li>
-            <li>
-Let |proofConfigHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-|canonicalProofConfig|. Respective |proofConfigHash|
-will be exactly 32 bytes in size.
-            </li>
-            <li>
-Let |hashData| be the result of joining |proofConfigHash| (the
-first hash) with |transformedDocumentHash| (the second hash).
-            </li>
-            <li>
-Return |hashData| as the <em>hash data</em>.
-            </li>
-          </ol>
-
-        </section>
-
+        
         <section>
           <h4>Proof Configuration (experimental-shs-2025)</h4>
 
           <p>
 The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-experimental-shs-2025">proof hashing algorithm</a>.
+that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
           </p>
 
           <p>
@@ -1327,12 +1153,12 @@ Section [[[#proof-configuration-experimental-falcon-2025]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-falcon-2025"></a> with |unsecuredDocument|,
+href="#transformation"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-falcon-2025]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
             </li>
             <li>
@@ -1387,12 +1213,12 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-falcon-2025"></a> with |unsecuredDocument| and
+href="#transformation"></a> with |unsecuredDocument| and
 |proofConfig| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-falcon-2025]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
           </li>
           <li>
@@ -1415,100 +1241,12 @@ Return a [=verification result=] with [=struct/items=]:
         </section>
 
         <section>
-          <h4>Transformation (experimental-falcon-2025)</h4>
-
-          <p>
-The following algorithm specifies how to transform an unsecured input document
-into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section [[[#hashing-experimental-falcon-2025]]].
-          </p>
-
-          <p>
-Required inputs to this algorithm are an
-<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
-unsecured data document</a> (|unsecuredDocument|) and
-transformation options (|options|). The
-transformation options MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and a cryptosuite
-identifier (|cryptosuite|). A <em>transformed data document</em> is
-produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
-encoding.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-If |options|.|type| is not set to the string
-`DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `experimental-falcon-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
-            </li>
-            <li>
-Let |canonicalDocument| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |unsecuredDocument|.
-            </li>
-            <li>
-Set |output| to the value of |canonicalDocument|.
-            </li>
-            <li>
-Return |canonicalDocument| as the <em>transformed data document</em>.
-            </li>
-          </ol>
-        </section>
-
-        <section>
-          <h4>Hashing (experimental-falcon-2025)</h4>
-
-          <p>
-The following algorithm specifies how to cryptographically hash a
-<em>transformed data document</em> and <em>proof configuration</em>
-into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section [[[#proof-serialization-experimental-falcon-2025]]] or
-Section [[[#proof-verification-experimental-falcon-2025]]].
-          </p>
-
-          <p>
-The required inputs to this algorithm are a <em>transformed data document</em>
-(|transformedDocument|) and <em>canonical proof configuration</em>
-(|canonicalProofConfig|). A single <em>hash data</em> value represented as
-series of bytes is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |transformedDocumentHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-respective |transformedDocument|.
-Respective |transformedDocumentHash| will be exactly 32 bytes
-in size.
-            </li>
-            <li>
-Let |proofConfigHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-|canonicalProofConfig|. Respective |proofConfigHash|
-will be exactly 32 bytes in size.
-            </li>
-            <li>
-Let |hashData| be the result of joining |proofConfigHash| (the
-first hash) with |transformedDocumentHash| (the second hash).
-            </li>
-            <li>
-Return |hashData| as the <em>hash data</em>.
-            </li>
-          </ol>
-
-        </section>
-
-        <section>
           <h4>Proof Configuration (experimental-falcon-2025)</h4>
 
           <p>
 The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-experimental-falcon-2025">proof hashing algorithm</a>.
+that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
           </p>
 
           <p>
@@ -1664,12 +1402,12 @@ Section [[[#proof-configuration-experimental-sqi-2025]]] with
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-sqi-2025"></a> with |unsecuredDocument|,
+href="#transformation"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-sqi-2025]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
             </li>
             <li>
@@ -1724,12 +1462,12 @@ value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-experimental-sqi-2025"></a> with |unsecuredDocument| and
+href="#transformation"></a> with |unsecuredDocument| and
 |proofConfig| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing-experimental-sqi-2025]]] with |transformedData| and |proofConfig|
+[[[#hashing]]] with |transformedData| and |proofConfig|
 passed as a parameters.
           </li>
           <li>
@@ -1751,141 +1489,7 @@ Return a [=verification result=] with [=struct/items=]:
 
         </section>
 
-        <section>
-          <h4>Transformation (experimental-sqi-2025)</h4>
-
-          <p>
-The following algorithm specifies how to transform an unsecured input document
-into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section [[[#hashing-experimental-sqi-2025]]].
-          </p>
-
-          <p>
-Required inputs to this algorithm are an
-<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
-unsecured data document</a> (|unsecuredDocument|) and
-transformation options (|options|). The
-transformation options MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and a cryptosuite
-identifier (|cryptosuite|). A <em>transformed data document</em> is
-produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
-encoding.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-If |options|.|type| is not set to the string
-`DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `experimental-sqi-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
-            </li>
-            <li>
-Let |canonicalDocument| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |unsecuredDocument|.
-            </li>
-            <li>
-Set |output| to the value of |canonicalDocument|.
-            </li>
-            <li>
-Return |canonicalDocument| as the <em>transformed data document</em>.
-            </li>
-          </ol>
-        </section>
-
-        <section>
-          <h4>Hashing (experimental-sqi-2025)</h4>
-
-          <p>
-The following algorithm specifies how to cryptographically hash a
-<em>transformed data document</em> and <em>proof configuration</em>
-into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section [[[#proof-serialization-experimental-sqi-2025]]] or
-Section [[[#proof-verification-experimental-sqi-2025]]].
-          </p>
-
-          <p>
-The required inputs to this algorithm are a <em>transformed data document</em>
-(|transformedDocument|) and <em>canonical proof configuration</em>
-(|canonicalProofConfig|). A single <em>hash data</em> value represented as
-series of bytes is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |transformedDocumentHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-respective |transformedDocument|.
-Respective |transformedDocumentHash| will be exactly 32 bytes
-in size.
-            </li>
-            <li>
-Let |proofConfigHash| be the result of applying the
-SHA-256 (SHA-2 with 256-bit output)
-cryptographic hashing algorithm [[RFC6234]] to the
-|canonicalProofConfig|. Respective |proofConfigHash|
-will be exactly 32 bytes in size.
-            </li>
-            <li>
-Let |hashData| be the result of joining |proofConfigHash| (the
-first hash) with |transformedDocumentHash| (the second hash).
-            </li>
-            <li>
-Return |hashData| as the <em>hash data</em>.
-            </li>
-          </ol>
-
-        </section>
-
-        <section>
-          <h4>Proof Configuration (experimental-sqi-2025)</h4>
-
-          <p>
-The following algorithm specifies how to generate a
-<em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-experimental-sqi-2025">proof hashing algorithm</a>.
-          </p>
-
-          <p>
-The required inputs to this algorithm are <em>proof options</em>
-(|options|). The <em>proof options</em> MUST contain a type identifier
-for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MUST contain a cryptosuite
-identifier (|cryptosuite|). A <em>proof configuration</em>
-object is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |proofConfig| be a clone of the |options| object.
-            </li>
-            <li>
-If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `experimental-sqi-2025`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
-            </li>
-            <li>
-If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
-raised.
-            </li>
-            <li>
-Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
-            </li>
-            <li>
-Let |canonicalProofConfig| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |proofConfig|.
-            </li>
-            <li>
-Return |canonicalProofConfig|.
-            </li>
-          </ol>
-
-        </section>
+        
 
         <section>
           <h4>Proof Serialization (experimental-sqi-2025)</h4>
@@ -1965,8 +1569,148 @@ Return |verificationResult| as the <em>verification result</em>.
 
         </section>
       </section>
+      <section>
+        <h3>Common Algorithms</h3>
+        <section>
+          <h4>Transformation</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section [[[#hashing]]].
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (|unsecuredDocument|) and
+transformation options (|options|). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and a cryptosuite
+identifier (|cryptosuite|). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If |options|.|type| is not set to the string
+`DataIntegrityProof` and |options|.|cryptosuite| is not
+set to the string `experimental-sqi-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let |canonicalDocument| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |unsecuredDocument|.
+            </li>
+            <li>
+Set |output| to the value of |canonicalDocument|.
+            </li>
+            <li>
+Return |canonicalDocument| as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>Hashing</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms for proof serialization and proof verification of each of the 
+respective cryptosuites.
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(|transformedDocument|) and <em>canonical proof configuration</em>
+(|canonicalProofConfig|). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |transformedDocumentHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective |transformedDocument|.
+Respective |transformedDocumentHash| will be exactly 32 bytes
+in size.
+            </li>
+            <li>
+Let |proofConfigHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+|canonicalProofConfig|. Respective |proofConfigHash|
+will be exactly 32 bytes in size.
+            </li>
+            <li>
+Let |hashData| be the result of joining |proofConfigHash| (the
+first hash) with |transformedDocumentHash| (the second hash).
+            </li>
+            <li>
+Return |hashData| as the <em>hash data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Configuration</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(|options|). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MUST contain a cryptosuite
+identifier (|cryptosuite|). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proofConfig| be a clone of the |options| object.
+            </li>
+            <li>
+If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
+|proofConfig|.|cryptosuite| is not set to TODO: `cryptosuite`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
+            </li>
+            <li>
+Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
+            </li>
+            <li>
+Let |canonicalProofConfig| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |proofConfig|.
+            </li>
+            <li>
+Return |canonicalProofConfig|.
+            </li>
+          </ol>
+
+        </section>
+    </section>
+
     </section>
     </section>
+
     </section>
 </section>
     

--- a/index.html
+++ b/index.html
@@ -478,6 +478,17 @@ base-64-url-nopad Multibase header (`u`). Any other encodings MUST NOT be
 allowed.
           </p>
 
+          <!-- <p>
+The encoding of a SHS-DSA secret key MUST start with the two-byte prefix
+`????` (the varint expression of `????`) followed by the 2528-byte secret
+key data. The 2530-byte value MUST then be encoded using the base-64-url-nopad
+alphabet, according to
+the <a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase</a> section in the
+[[VC-DATA-INTEGRITY]] specification, and then prepended with the
+base-64-url-nopad Multibase header (`u`). Any other encodings MUST NOT be
+allowed.
+          </p> -->
+
           <p class="advisement">
 Developers are advised to prevent accidental publication of a representation of
 a secret key, and to not export the `secretKeyMultibase` property by default,

--- a/index.html
+++ b/index.html
@@ -706,8 +706,8 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-experimental-mldsa44-2024]]] with
-|options| passed as a parameter.
+Section [[[#proof-configuration]]] with
+|options| and `experimental-mldsa44-2024` passed as parameters.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
@@ -793,55 +793,6 @@ Return a [=verification result=] with [=struct/items=]:
                 <dd>
 |unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
               </dl>
-            </li>
-          </ol>
-
-        </section>
-
-        
-        <section>
-          <h4>Proof Configuration (experimental-mldsa44-2024)</h4>
-
-          <p>
-The following algorithm specifies how to generate a
-<em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
-          </p>
-
-          <p>
-The required inputs to this algorithm are <em>proof options</em>
-(|options|). The <em>proof options</em> MUST contain a type identifier
-for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MUST contain a cryptosuite
-identifier (|cryptosuite|). A <em>proof configuration</em>
-object is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |proofConfig| be a clone of the |options| object.
-            </li>
-            <li>
-If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `experimental-mldsa44-2024`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
-            </li>
-            <li>
-If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
-raised.
-            </li>
-            <li>
-Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
-            </li>
-            <li>
-Let |canonicalProofConfig| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |proofConfig|.
-            </li>
-            <li>
-Return |canonicalProofConfig|.
             </li>
           </ol>
 
@@ -954,8 +905,8 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-experimental-shs-2025]]] with
-|options| passed as a parameter.
+Section [[[#proof-configuration]]] with
+|options| and `experimental-shs-2025` passed as parameters.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
@@ -1041,55 +992,6 @@ Return a [=verification result=] with [=struct/items=]:
                 <dd>
 |unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
               </dl>
-            </li>
-          </ol>
-
-        </section>
-
-        
-        <section>
-          <h4>Proof Configuration (experimental-shs-2025)</h4>
-
-          <p>
-The following algorithm specifies how to generate a
-<em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
-          </p>
-
-          <p>
-The required inputs to this algorithm are <em>proof options</em>
-(|options|). The <em>proof options</em> MUST contain a type identifier
-for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MUST contain a cryptosuite
-identifier (|cryptosuite|). A <em>proof configuration</em>
-object is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |proofConfig| be a clone of the |options| object.
-            </li>
-            <li>
-If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `experimental-shs-2025`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
-            </li>
-            <li>
-If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
-raised.
-            </li>
-            <li>
-Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
-            </li>
-            <li>
-Let |canonicalProofConfig| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |proofConfig|.
-            </li>
-            <li>
-Return |canonicalProofConfig|.
             </li>
           </ol>
 
@@ -1204,8 +1106,8 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-experimental-falcon-2025]]] with
-|options| passed as a parameter.
+Section [[[#proof-configuration]]] with
+|options| and `experimental-falcon-2025` passed as parameters.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
@@ -1291,54 +1193,6 @@ Return a [=verification result=] with [=struct/items=]:
                 <dd>
 |unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
               </dl>
-            </li>
-          </ol>
-
-        </section>
-
-        <section>
-          <h4>Proof Configuration (experimental-falcon-2025)</h4>
-
-          <p>
-The following algorithm specifies how to generate a
-<em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
-          </p>
-
-          <p>
-The required inputs to this algorithm are <em>proof options</em>
-(|options|). The <em>proof options</em> MUST contain a type identifier
-for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MUST contain a cryptosuite
-identifier (|cryptosuite|). A <em>proof configuration</em>
-object is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |proofConfig| be a clone of the |options| object.
-            </li>
-            <li>
-If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `experimental-falcon-2025`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
-            </li>
-            <li>
-If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
-raised.
-            </li>
-            <li>
-Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
-            </li>
-            <li>
-Let |canonicalProofConfig| be the result of applying the
-Universal RDF Dataset Canonicalization Algorithm
-[[RDF-CANON]] to the |proofConfig|.
-            </li>
-            <li>
-Return |canonicalProofConfig|.
             </li>
           </ol>
 
@@ -1453,8 +1307,8 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration-experimental-sqi-2025]]] with
-|options| passed as a parameter.
+Section [[[#proof-configuration]]] with
+|options| and `experimental-sqi-2025` passed as parameters.
             </li>
             <li>
 Let |transformedData| be the result of running the algorithm in Section <a
@@ -1726,10 +1580,10 @@ that is used as input to the <a href="#hashing">proof hashing algorithm</a>.
 
           <p>
 The required inputs to this algorithm are <em>proof options</em>
-(|options|). The <em>proof options</em> MUST contain a type identifier
+(|options|) and a <em>cryptosuite identifier</em> (|cryptosuite|). The <em>proof options</em> MUST contain a type identifier
 for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MUST contain a cryptosuite
+cryptographic suite</a> (|type|) and MUST contain the cryptosuite
 identifier (|cryptosuite|). A <em>proof configuration</em>
 object is produced as output.
           </p>
@@ -1740,7 +1594,7 @@ Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to TODO: `cryptosuite`, an
+|proofConfig|.|cryptosuite| is not set to `cryptosuite`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1700,6 +1700,11 @@ Return |canonicalProofConfig|.
 
         </section>
     </section>
+    </section>
+    </section>
+</section>
+    
+    
 
     </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -956,9 +956,7 @@ Return |verificationResult| as the <em>verification result</em>.
 
         </section>
       </section>
-    </section>
-
-    <section>
+      <section>
         <h3>experimental-shs-2025</h3>
 
         <p>
@@ -1294,9 +1292,8 @@ Return |verificationResult| as the <em>verification result</em>.
 
         </section>
       </section>
-    </section>
 
-    <section>
+      <section>
         <h3>experimental-falcon-2025</h3>
 
         <p>
@@ -1631,9 +1628,9 @@ Return |verificationResult| as the <em>verification result</em>.
 
         </section>
       </section>
-    </section>
+    
 
-    <section>
+      <section>
         <h3>experimental-sqi-2025</h3>
 
         <p>
@@ -1969,6 +1966,11 @@ Return |verificationResult| as the <em>verification result</em>.
         </section>
       </section>
     </section>
+    </section>
+    </section>
+</section>
+    
+    
 
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -958,6 +958,1019 @@ Return |verificationResult| as the <em>verification result</em>.
       </section>
     </section>
 
+    <section>
+        <h3>experimental-shs-2025</h3>
+
+        <p>
+The `experimental-shs-2025` cryptographic suite takes an
+input document, canonicalizes the document using the Universal RDF Dataset
+Canonicalization Algorithm [[RDF-CANON]], and then cryptographically hashes and
+signs the output resulting in the production of a data integrity proof. The
+algorithms in this section also include the verification of such a data
+integrity proof.
+        </p>
+
+        <section>
+          <h4>Create Proof (experimental-shs-2025)</h4>
+
+          <p>
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proof| be a clone of the proof options, |options|.
+            </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration-experimental-shs-2025]]] with
+|options| passed as a parameter.
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-experimental-shs-2025"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
+            </li>
+            <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#hashing-experimental-shs-2025]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+            </li>
+            <li>
+Let |proofBytes| be the result of running the algorithm in Section
+[[[#proof-serialization-experimental-shs-2025]]] with |hashData| and
+|options| passed as parameters.
+            </li>
+            <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base58-btc-encoded Multibase value</a> of the |proofBytes|.
+            </li>
+            <li>
+Return |proof| as the [=data integrity proof=].
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Verify Proof (experimental-shs-2025)</h4>
+
+          <p>
+The following algorithm specifies how to verify a [=data integrity proof=] given
+an <a>secured data document</a>. Required inputs are an
+<a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
+a <dfn>verification result</dfn>, which is a [=struct=] whose
+[=struct/items=] are:
+          </p>
+          <dl>
+            <dt><dfn data-dfn-for="verification result">verified</dfn></dt>
+            <dd>`true` or `false`</dd>
+            <dt><dfn data-dfn-for="verification result">verifiedDocument</dfn></dt>
+            <dd>
+<a data-cite="INFRA#nulls">Null</a>, if [=verification result/verified=] is
+`false`; otherwise, an [=unsecured data document=]
+            </dd>
+          </dl>
+
+          <ol class="algorithm">
+          <li>
+Let |unsecuredDocument| be a copy of |securedDocument| with
+the `proof` value removed.
+          </li>
+          <li>
+Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+removed.
+          </li>
+          <li>
+Let |proofBytes| be the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+value</a> in |securedDocument|.|proof|.|proofValue|.
+          </li>
+          <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-experimental-shs-2025"></a> with |unsecuredDocument| and
+|proofConfig| passed as parameters.
+          </li>
+          <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#hashing-experimental-shs-2025]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+          </li>
+          <li>
+Let |verified:boolean| be the result of running the algorithm in Section
+[[[#proof-verification-experimental-shs-2025]]] algorithm on |hashData|,
+|proofBytes|, and |proofConfig|.
+            </li>
+            <li>
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>|verified|</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+              </dl>
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Transformation (experimental-shs-2025)</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section [[[#hashing-experimental-shs-2025]]].
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (|unsecuredDocument|) and
+transformation options (|options|). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and a cryptosuite
+identifier (|cryptosuite|). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If |options|.|type| is not set to the string
+`DataIntegrityProof` and |options|.|cryptosuite| is not
+set to the string `experimental-shs-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let |canonicalDocument| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |unsecuredDocument|.
+            </li>
+            <li>
+Set |output| to the value of |canonicalDocument|.
+            </li>
+            <li>
+Return |canonicalDocument| as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>Hashing (experimental-shs-2025)</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section [[[#proof-serialization-experimental-shs-2025]]] or
+Section [[[#proof-verification-experimental-shs-2025]]].
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(|transformedDocument|) and <em>canonical proof configuration</em>
+(|canonicalProofConfig|). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |transformedDocumentHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective |transformedDocument|.
+Respective |transformedDocumentHash| will be exactly 32 bytes
+in size.
+            </li>
+            <li>
+Let |proofConfigHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+|canonicalProofConfig|. Respective |proofConfigHash|
+will be exactly 32 bytes in size.
+            </li>
+            <li>
+Let |hashData| be the result of joining |proofConfigHash| (the
+first hash) with |transformedDocumentHash| (the second hash).
+            </li>
+            <li>
+Return |hashData| as the <em>hash data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Configuration (experimental-shs-2025)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-experimental-shs-2025">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(|options|). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MUST contain a cryptosuite
+identifier (|cryptosuite|). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proofConfig| be a clone of the |options| object.
+            </li>
+            <li>
+If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
+|proofConfig|.|cryptosuite| is not set to `experimental-shs-2025`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
+            </li>
+            <li>
+Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
+            </li>
+            <li>
+Let |canonicalProofConfig| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |proofConfig|.
+            </li>
+            <li>
+Return |canonicalProofConfig|.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Serialization (experimental-shs-2025)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (|hashData|) and
+<em>proof options</em> (|options|). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MAY contain a cryptosuite
+identifier (|cryptosuite|). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |privateKeyBytes| be the result of retrieving the
+private key bytes (or a signing interface enabling the use of the private key
+bytes) associated with the verification method identified by the
+|options|.|verificationMethod| value.
+            </li>
+            <li>
+Let |proofBytes| be the result of applying the Stateless Hash-Based Signature (SHS)
+Algorithm [[TODO SHS PAPER]], with |hashData| as the data
+to be signed using the private key specified by |privateKeyBytes|.
+|proofBytes| will be exactly ??? bytes in size.
+            </li>
+            <li>
+Return |proofBytes| as the <em>digital proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Verification (experimental-shs-2025)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (|hashData|),
+a digital signature (|proofBytes|) and
+proof options (|options|). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |publicKeyBytes| be the result of retrieving the
+public key bytes associated with the
+|options|.|verificationMethod| value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieve Verification Method</a>.
+            </li>
+            <li>
+Let |verificationResult| be the result of applying the verification
+algorithm for the Stateless Hash-Based Signature (SHS)
+scheme [[TODO SHS PAPER]],
+with |hashData| as the data to be verified against the
+|proofBytes| using the public key specified by
+|publicKeyBytes|.
+            </li>
+            <li>
+Return |verificationResult| as the <em>verification result</em>.
+            </li>
+          </ol>
+
+        </section>
+      </section>
+    </section>
+
+    <section>
+        <h3>experimental-falcon-2025</h3>
+
+        <p>
+The `experimental-falcon-2025` cryptographic suite takes an
+input document, canonicalizes the document using the Universal RDF Dataset
+Canonicalization Algorithm [[RDF-CANON]], and then cryptographically hashes and
+signs the output resulting in the production of a data integrity proof. The
+algorithms in this section also include the verification of such a data
+integrity proof.
+        </p>
+
+        <section>
+          <h4>Create Proof (experimental-falcon-2025)</h4>
+
+          <p>
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proof| be a clone of the proof options, |options|.
+            </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration-experimental-falcon-2025]]] with
+|options| passed as a parameter.
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-experimental-falcon-2025"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
+            </li>
+            <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#hashing-experimental-falcon-2025]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+            </li>
+            <li>
+Let |proofBytes| be the result of running the algorithm in Section
+[[[#proof-serialization-experimental-falcon-2025]]] with |hashData| and
+|options| passed as parameters.
+            </li>
+            <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base58-btc-encoded Multibase value</a> of the |proofBytes|.
+            </li>
+            <li>
+Return |proof| as the [=data integrity proof=].
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Verify Proof (experimental-falcon-2025)</h4>
+
+          <p>
+The following algorithm specifies how to verify a [=data integrity proof=] given
+an <a>secured data document</a>. Required inputs are an
+<a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
+a <dfn>verification result</dfn>, which is a [=struct=] whose
+[=struct/items=] are:
+          </p>
+          <dl>
+            <dt><dfn data-dfn-for="verification result">verified</dfn></dt>
+            <dd>`true` or `false`</dd>
+            <dt><dfn data-dfn-for="verification result">verifiedDocument</dfn></dt>
+            <dd>
+<a data-cite="INFRA#nulls">Null</a>, if [=verification result/verified=] is
+`false`; otherwise, an [=unsecured data document=]
+            </dd>
+          </dl>
+
+          <ol class="algorithm">
+          <li>
+Let |unsecuredDocument| be a copy of |securedDocument| with
+the `proof` value removed.
+          </li>
+          <li>
+Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+removed.
+          </li>
+          <li>
+Let |proofBytes| be the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+value</a> in |securedDocument|.|proof|.|proofValue|.
+          </li>
+          <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-experimental-falcon-2025"></a> with |unsecuredDocument| and
+|proofConfig| passed as parameters.
+          </li>
+          <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#hashing-experimental-falcon-2025]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+          </li>
+          <li>
+Let |verified:boolean| be the result of running the algorithm in Section
+[[[#proof-verification-experimental-falcon-2025]]] algorithm on |hashData|,
+|proofBytes|, and |proofConfig|.
+            </li>
+            <li>
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>|verified|</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+              </dl>
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Transformation (experimental-falcon-2025)</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section [[[#hashing-experimental-falcon-2025]]].
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (|unsecuredDocument|) and
+transformation options (|options|). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and a cryptosuite
+identifier (|cryptosuite|). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If |options|.|type| is not set to the string
+`DataIntegrityProof` and |options|.|cryptosuite| is not
+set to the string `experimental-falcon-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let |canonicalDocument| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |unsecuredDocument|.
+            </li>
+            <li>
+Set |output| to the value of |canonicalDocument|.
+            </li>
+            <li>
+Return |canonicalDocument| as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>Hashing (experimental-falcon-2025)</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section [[[#proof-serialization-experimental-falcon-2025]]] or
+Section [[[#proof-verification-experimental-falcon-2025]]].
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(|transformedDocument|) and <em>canonical proof configuration</em>
+(|canonicalProofConfig|). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |transformedDocumentHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective |transformedDocument|.
+Respective |transformedDocumentHash| will be exactly 32 bytes
+in size.
+            </li>
+            <li>
+Let |proofConfigHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+|canonicalProofConfig|. Respective |proofConfigHash|
+will be exactly 32 bytes in size.
+            </li>
+            <li>
+Let |hashData| be the result of joining |proofConfigHash| (the
+first hash) with |transformedDocumentHash| (the second hash).
+            </li>
+            <li>
+Return |hashData| as the <em>hash data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Configuration (experimental-falcon-2025)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-experimental-falcon-2025">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(|options|). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MUST contain a cryptosuite
+identifier (|cryptosuite|). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proofConfig| be a clone of the |options| object.
+            </li>
+            <li>
+If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
+|proofConfig|.|cryptosuite| is not set to `experimental-falcon-2025`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
+            </li>
+            <li>
+Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
+            </li>
+            <li>
+Let |canonicalProofConfig| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |proofConfig|.
+            </li>
+            <li>
+Return |canonicalProofConfig|.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Serialization (experimental-falcon-2025)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (|hashData|) and
+<em>proof options</em> (|options|). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MAY contain a cryptosuite
+identifier (|cryptosuite|). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |privateKeyBytes| be the result of retrieving the
+private key bytes (or a signing interface enabling the use of the private key
+bytes) associated with the verification method identified by the
+|options|.|verificationMethod| value.
+            </li>
+            <li>
+Let |proofBytes| be the result of applying the Falcon
+Signature Algorithm [[TODO FALCON PAPER]], with |hashData| as the data
+to be signed using the private key specified by |privateKeyBytes|.
+|proofBytes| will be exactly ??? bytes in size.
+            </li>
+            <li>
+Return |proofBytes| as the <em>digital proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Verification (experimental-falcon-2025)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (|hashData|),
+a digital signature (|proofBytes|) and
+proof options (|options|). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |publicKeyBytes| be the result of retrieving the
+public key bytes associated with the
+|options|.|verificationMethod| value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieve Verification Method</a>.
+            </li>
+            <li>
+Let |verificationResult| be the result of applying the verification
+algorithm from the Falcon Digital Signature scheme [[TODO Falcon Paper]],
+with |hashData| as the data to be verified against the
+|proofBytes| using the public key specified by
+|publicKeyBytes|.
+            </li>
+            <li>
+Return |verificationResult| as the <em>verification result</em>.
+            </li>
+          </ol>
+
+        </section>
+      </section>
+    </section>
+
+    <section>
+        <h3>experimental-sqi-2025</h3>
+
+        <p>
+The `experimental-sqi-2025` cryptographic suite takes an
+input document, canonicalizes the document using the Universal RDF Dataset
+Canonicalization Algorithm [[RDF-CANON]], and then cryptographically hashes and
+signs the output resulting in the production of a data integrity proof. The
+algorithms in this section also include the verification of such a data
+integrity proof.
+        </p>
+
+        <section>
+          <h4>Create Proof (experimental-sqi-2025)</h4>
+
+          <p>
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proof| be a clone of the proof options, |options|.
+            </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#proof-configuration-experimental-sqi-2025]]] with
+|options| passed as a parameter.
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-experimental-sqi-2025"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
+            </li>
+            <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#hashing-experimental-sqi-2025]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+            </li>
+            <li>
+Let |proofBytes| be the result of running the algorithm in Section
+[[[#proof-serialization-experimental-sqi-2025]]] with |hashData| and
+|options| passed as parameters.
+            </li>
+            <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base58-btc-encoded Multibase value</a> of the |proofBytes|.
+            </li>
+            <li>
+Return |proof| as the [=data integrity proof=].
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Verify Proof (experimental-sqi-2025)</h4>
+
+          <p>
+The following algorithm specifies how to verify a [=data integrity proof=] given
+an <a>secured data document</a>. Required inputs are an
+<a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
+a <dfn>verification result</dfn>, which is a [=struct=] whose
+[=struct/items=] are:
+          </p>
+          <dl>
+            <dt><dfn data-dfn-for="verification result">verified</dfn></dt>
+            <dd>`true` or `false`</dd>
+            <dt><dfn data-dfn-for="verification result">verifiedDocument</dfn></dt>
+            <dd>
+<a data-cite="INFRA#nulls">Null</a>, if [=verification result/verified=] is
+`false`; otherwise, an [=unsecured data document=]
+            </dd>
+          </dl>
+
+          <ol class="algorithm">
+          <li>
+Let |unsecuredDocument| be a copy of |securedDocument| with
+the `proof` value removed.
+          </li>
+          <li>
+Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+removed.
+          </li>
+          <li>
+Let |proofBytes| be the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+value</a> in |securedDocument|.|proof|.|proofValue|.
+          </li>
+          <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-experimental-sqi-2025"></a> with |unsecuredDocument| and
+|proofConfig| passed as parameters.
+          </li>
+          <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#hashing-experimental-sqi-2025]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+          </li>
+          <li>
+Let |verified:boolean| be the result of running the algorithm in Section
+[[[#proof-verification-experimental-sqi-2025]]] algorithm on |hashData|,
+|proofBytes|, and |proofConfig|.
+            </li>
+            <li>
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>|verified|</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+              </dl>
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Transformation (experimental-sqi-2025)</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section [[[#hashing-experimental-sqi-2025]]].
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (|unsecuredDocument|) and
+transformation options (|options|). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and a cryptosuite
+identifier (|cryptosuite|). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If |options|.|type| is not set to the string
+`DataIntegrityProof` and |options|.|cryptosuite| is not
+set to the string `experimental-sqi-2025` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let |canonicalDocument| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |unsecuredDocument|.
+            </li>
+            <li>
+Set |output| to the value of |canonicalDocument|.
+            </li>
+            <li>
+Return |canonicalDocument| as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>Hashing (experimental-sqi-2025)</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section [[[#proof-serialization-experimental-sqi-2025]]] or
+Section [[[#proof-verification-experimental-sqi-2025]]].
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(|transformedDocument|) and <em>canonical proof configuration</em>
+(|canonicalProofConfig|). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |transformedDocumentHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective |transformedDocument|.
+Respective |transformedDocumentHash| will be exactly 32 bytes
+in size.
+            </li>
+            <li>
+Let |proofConfigHash| be the result of applying the
+SHA-256 (SHA-2 with 256-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+|canonicalProofConfig|. Respective |proofConfigHash|
+will be exactly 32 bytes in size.
+            </li>
+            <li>
+Let |hashData| be the result of joining |proofConfigHash| (the
+first hash) with |transformedDocumentHash| (the second hash).
+            </li>
+            <li>
+Return |hashData| as the <em>hash data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Configuration (experimental-sqi-2025)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-experimental-sqi-2025">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(|options|). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MUST contain a cryptosuite
+identifier (|cryptosuite|). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proofConfig| be a clone of the |options| object.
+            </li>
+            <li>
+If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
+|proofConfig|.|cryptosuite| is not set to `experimental-sqi-2025`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+If |proofConfig|.|created| is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
+            </li>
+            <li>
+Set |proofConfig|.|@context| to |unsecuredDocument|.|@context|.
+            </li>
+            <li>
+Let |canonicalProofConfig| be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the |proofConfig|.
+            </li>
+            <li>
+Return |canonicalProofConfig|.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Serialization (experimental-sqi-2025)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (|hashData|) and
+<em>proof options</em> (|options|). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MAY contain a cryptosuite
+identifier (|cryptosuite|). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |privateKeyBytes| be the result of retrieving the
+private key bytes (or a signing interface enabling the use of the private key
+bytes) associated with the verification method identified by the
+|options|.|verificationMethod| value.
+            </li>
+            <li>
+Let |proofBytes| be the result of applying the SQISign
+Signature Algorithm [[TODO: SQI Paper]], with |hashData| as the data
+to be signed using the private key specified by |privateKeyBytes|.
+|proofBytes| will be exactly ??? bytes in size.
+            </li>
+            <li>
+Return |proofBytes| as the <em>digital proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Verification (experimental-sqi-2025)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (|hashData|),
+a digital signature (|proofBytes|) and
+proof options (|options|). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |publicKeyBytes| be the result of retrieving the
+public key bytes associated with the
+|options|.|verificationMethod| value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieve Verification Method</a>.
+            </li>
+            <li>
+Let |verificationResult| be the result of applying the verification
+algorithm for the SQISign Algorithm [[TODO: SQI Paper]],
+with |hashData| as the data to be verified against the
+|proofBytes| using the public key specified by
+|publicKeyBytes|.
+            </li>
+            <li>
+Return |verificationResult| as the <em>verification result</em>.
+            </li>
+          </ol>
+
+        </section>
+      </section>
+    </section>
+
+
     <section class="informative">
       <h2>Security Considerations</h2>
 
@@ -1003,7 +2016,7 @@ specification over time.
       </p>
 
       <p>
-TBD...
+Added cryptosuite algorithms for Stateless Hash-Based Signatures, Falcon, and SQISign.
       </p>
 
     </section>


### PR DESCRIPTION
Per discussion here: https://lists.w3.org/Archives/Public/public-credentials/2025Apr/0013.html

Adding new algorithms for: Falcon, Stateless hash-based signatures and SQISign.

This is a work in progress, I still need to add appropriate references and check signature sizes. I think I also need to review and tidy up the data integrity section to mention the new algs.

I have some questions:

1. Should I refactor this to avoid duplication of transformation, hashing and proof config algs
2. Are these all still experimental?
3. Who can help generate some examples?
4. If anyone can drop the appropiate links to the algorithms we want to reference that would be great.

cc @msporny, @dlongley


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/di-quantum-safe/pull/4.html" title="Last updated on Jun 17, 2025, 4:11 PM UTC (3906f19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/di-quantum-safe/4/9e0d957...wip-abramson:3906f19.html" title="Last updated on Jun 17, 2025, 4:11 PM UTC (3906f19)">Diff</a>