### PR TITLE
FALCON and  SQIsign Updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1445,7 +1445,7 @@ be updated when the NIST specification is issued.
         </p>
         <p>
 FALCON is a lattice-based signature scheme. It stands for the following acronym:
-<u>Fa</u>st Fourier <u>l</u>attice-based <u>co</u>mpact signatures over 
+<u>FA</u>st Fourier <u>L</u>attice-based <u>CO</u>mpact signatures over 
 <u>N</u>TRU. FALCON defines parameter sets for two different claimed security
 strengths. The
 claimed security strengths, private key, public key, and signature sizes are
@@ -1612,7 +1612,7 @@ removed.
 Set |cryptosuiteName| to |securedDocument|.|proof|.|cryptosuite|,
 which must be one of those listed in [[[#FALCONSuitesTable]]].
 From |cryptosuiteName|, set the values of |canonScheme|, |hashName|,
-and |verifyFunc|, as found in [[[#MLSuitesTable]]].
+and |verifyFunc|, as found in [[[#FALCONSuitesTable]]].
           </li>
           <li>
 Let |proofBytes| be the
@@ -1653,26 +1653,101 @@ Return a [=verification result=] with [=struct/items=]:
           </ol>
 
         </section>
-
+      </section>
 
       <section id="SQISign_Cryptosuites">
-        <h3>experimental-sqi-2025</h3>
-
+        <h3>SQIsign Cryptosuites</h3>
+        <p  class="ednote">
+The <a href="https://sqisign.org/">SQIsign</a> signature algorithm has been 
+submitted to NIST. SQIsign aims for very compact key and signature sizes. 
+The information presented here is based on 
+<a href="https://sqisign.org/spec/sqisign-20250707.pdf">specification v2.01, 
+2025-07-07</a>. This section will be updated as appropriate.
+        </p>
         <p>
-The `experimental-sqi-2025` cryptographic suite takes an
-input document, canonicalizes the document using the Universal RDF Dataset
-Canonicalization Algorithm [[RDF-CANON]], and then cryptographically hashes and
-signs the output resulting in the production of a data integrity proof. The
-algorithms in this section also include the verification of such a data
-integrity proof.
+SQIsign relies on the hardness of a computational problem from number theory: 
+computing the endomorphism ring of a supersingular elliptic curve, the 
+endomorphism ring problem. SQIsign defines parameter sets for three different 
+claimed security strengths. The claimed security strengths, private key, public 
+key, and signature sizes are summarized in [[[#SQISummaryTable]]].
         </p>
 
+        <table id="SQISummaryTable" class="data numbered">
+          <caption><em>SQIsign Signatures Summary, all sizes in bytes.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Security</th>
+              <th>Private Key</th>
+              <th>Public Key</th>
+              <th>Signature</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>SQIsign-I</td>
+              <td>Category 1</td>
+              <td>353</td>
+              <td>65</td>
+              <td>148</td>
+            </tr>
+            <tr>
+              <td>SQIsign-III</td>
+              <td>Category 3</td>
+              <td>529</td>
+              <td>97</td>
+              <td>224</td>
+            </tr>
+            <tr>
+              <td>SQIsign-V</td>
+              <td>Category 5</td>
+              <td>701</td>
+              <td>129</td>
+              <td>292</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+Supporting both the Universal RDF Dataset Canonicalization Algorithm [[RDF-CANON]],
+"`rdfc`", the JSON Canonicalization Scheme [[RFC8785]], "`jcs`", and a maximum
+security category of 1, leads to the
+family of SQIsign cryptosuites given in [[[#SQISuitesTable]]].
+        </p>
+        <table id="SQISuitesTable" class="data numbered">
+          <caption><em>Supported SQIsign Cryptosuites.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Canonalization</th>
+              <th>Signature/Verification</th>
+              <th>Hash</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>`sqisign1-rdfc-2024`</td>
+              <td>RDFC</td>
+              <td>SQIsign-I</td>
+              <td>SHA-256</td>
+            </tr>
+            <tr>
+              <td>`sqisign1-jcs-2024`</td>
+              <td>JCS</td>
+              <td>SQIsign-I</td>
+              <td>SHA-256</td>
+            </tr>
+          </tbody>
+        </table>
         <section>
-          <h4>Create Proof (experimental-sqi-2025)</h4>
+          <h4>Create Proof (SQIsign)</h4>
 
           <p>
 The following algorithm specifies how to create a [=data integrity proof=] given
-an <a>unsecured data document</a>. Required inputs are an
+an <a>unsecured data document</a> and a SQIsign cryptosuite chosen from
+[[[#SQISuitesTable]]]. The choice of cryptosuite sets the values of |canonScheme|,
+|hashName|, |sigFunc|, and |verifyFunc| per [[[#SQISuitesTable]]], which are used
+in the algorithm below. Additional required inputs are an
 <a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
 options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
 is produced as output.
@@ -1684,27 +1759,28 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration]]] with
-|options| and `experimental-sqi-2025` passed as parameters.
+Section [[[#ProofConfigurationAlg]]] with
+|options|, the |cypherSuiteName|, |canonScheme|, and |hashName|
+passed as parameters.
             </li>
             <li>
-Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |options|, and
-`experimental-sqi-2025` passed as parameters.
+Let |transformedData| be the result of running the algorithm in Section
+[[[#TransformationAlg]]] with |unsecuredDocument|, |options|, the
+|cypherSuiteName|, |canonScheme|, and |hashName| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing]]] with |transformedData| and |proofConfig|
+[[[#HashingAlg]]] with |transformedData|, |proofConfig|, and |hashName|
 passed as a parameters.
             </li>
             <li>
 Let |proofBytes| be the result of running the algorithm in Section
-[[[#proof-serialization-experimental-sqi-2025]]] with |hashData| and
-|options| passed as parameters.
+[[[#ProofSerializationAlg]]] with |hashData|, |options|, and
+|sigFunc| passed as parameters.
             </li>
             <li>
 Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
-base58-btc-encoded Multibase value</a> of the |proofBytes|.
+base64-url-encoded Multibase encoding</a> of the |proofBytes|.
             </li>
             <li>
 Return |proof| as the [=data integrity proof=].
@@ -1714,11 +1790,11 @@ Return |proof| as the [=data integrity proof=].
         </section>
 
         <section>
-          <h4>Verify Proof (experimental-sqi-2025)</h4>
+          <h4>Verify Proof (SQIsign)</h4>
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
-an <a>secured data document</a>. Required input is a
+an <a>secured data document</a>. Required inputs are an
 <a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
 a <dfn>verification result</dfn>, which is a [=struct=] whose
 [=struct/items=] are:
@@ -1743,29 +1819,36 @@ Let |proofOptions| be a copy of |securedDocument|.|proof| with `proofValue`
 removed.
           </li>
           <li>
+Set |cryptosuiteName| to |securedDocument|.|proof|.|cryptosuite|,
+which must be one of those listed in [[[#SQISuitesTable]]].
+From |cryptosuiteName|, set the values of |canonScheme|, |hashName|,
+and |verifyFunc|, as found in [[[#SQISuitesTable]]].
+          </li>
+          <li>
 Let |proofBytes| be the
-<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base64-url
 value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
-Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |proofOptions|, and
-`experimental-sqi-2025` passed as parameters.
+Let |transformedData| be the result of running the algorithm in Section
+[[[#TransformationAlg]]] with |unsecuredDocument|,
+and |cypherSuiteName|,
+|canonScheme|, and |hashName| |proofOptions| passed as parameters.
           </li>
           <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration]]] with
-|options| and `experimental-sqi-2025` passed as parameters.
+Section [[[#ProofConfigurationAlg]]] with |options|, |cypherSuiteName|,
+|canonScheme|, and |hashName| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing]]] with |transformedData| and |proofConfig|
+[[[#HashingAlg]]] with |transformedData|, |proofConfig|, and |hashName|
 passed as a parameters.
           </li>
           <li>
 Let |verified:boolean| be the result of running the algorithm in Section
-[[[#proof-verification-experimental-sqi-2025]]] algorithm on |hashData|,
-|proofBytes|, and |proofConfig|.
+[[[#ProofVerificationAlg]]] with |hashData|,
+|proofBytes|, |proofConfig|, and |verifyFunc| as parameters.
             </li>
             <li>
 Return a [=verification result=] with [=struct/items=]:
@@ -1774,88 +1857,9 @@ Return a [=verification result=] with [=struct/items=]:
                 <dd>|verified|</dd>
                 <dt>[=verifiedDocument=]</dt>
                 <dd>
-|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+|unsecuredDocument| if |verified| is `true`, otherwise 
+<a data-cite="INFRA#nulls">Null</a></dd>
               </dl>
-            </li>
-          </ol>
-
-        </section>
-
-
-
-        <section>
-          <h4>Proof Serialization (experimental-sqi-2025)</h4>
-
-          <p>
-The following algorithm specifies how to serialize a digital signature from
-a set of cryptographic hash data. This
-algorithm is designed to be used in conjunction with the algorithms defined
-in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Algorithms</a>. Required inputs are
-cryptographic hash data (|hashData|) and
-<em>proof options</em> (|options|). The
-<em>proof options</em> MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MAY contain a cryptosuite
-identifier (|cryptosuite|). A single <em>digital proof</em> value
-represented as series of bytes is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |privateKeyBytes| be the result of retrieving the
-private key bytes (or a signing interface enabling the use of the private key
-bytes) associated with the verification method identified by the
-|options|.|verificationMethod| value.
-            </li>
-            <li>
-Let |proofBytes| be the result of applying the SQISign
-Signature Algorithm [[SQISIGN]], with |hashData| as the data
-to be signed using the private key specified by |privateKeyBytes|.
-|proofBytes| will be exactly 148 bytes in size.
-            </li>
-            <li>
-Return |proofBytes| as the <em>digital proof</em>.
-            </li>
-          </ol>
-
-        </section>
-
-        <section>
-          <h4>Proof Verification (experimental-sqi-2025)</h4>
-
-          <p>
-The following algorithm specifies how to verify a digital signature from
-a set of cryptographic hash data. This
-algorithm is designed to be used in conjunction with the algorithms defined
-in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Algorithms</a>. Required inputs are
-cryptographic hash data (|hashData|),
-a digital signature (|proofBytes|), and
-proof options (|options|). A <em>verification result</em>
-represented as a boolean value is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |publicKeyBytes| be the result of retrieving the
-public key bytes associated with the
-|options|.|verificationMethod| value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieve Verification Method</a>.
-            </li>
-            <li>
-Let |verificationResult| be the result of applying the verification
-algorithm for the SQISign Algorithm [[SQISIGN]],
-with |hashData| as the data to be verified against the
-|proofBytes| using the public key specified by
-|publicKeyBytes|.
-            </li>
-            <li>
-Return |verificationResult| as the <em>verification result</em>.
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -1434,28 +1434,110 @@ Return a [=verification result=] with [=struct/items=]:
       </section>
 
       <section id="Falcon_Cryptosuites">
-        <h3>experimental-falcon-2025</h3>
-<!-- **TODO**: Update and broaden, Maybe wait for FIPS-206 to come out
- Want this to deal with a "Group" of cryptosuites based on FALCON at three
- security levels, utilizing both RDFC and JCS canonicalization, with appropriate
- hashing function. Can also indicate public key and signature sizes here in
- a table.
--->
-        <p>
-The `experimental-falcon-2025` cryptographic suite takes an
-input document, canonicalizes the document using the Universal RDF Dataset
-Canonicalization Algorithm [[RDF-CANON]], and then cryptographically hashes and
-signs the output resulting in the production of a data integrity proof. The
-algorithms in this section also include the verification of such a data
-integrity proof.
+        <h3>FALCON Cryptosuites</h3>
+        <p  class="ednote">
+The <a href="https://falcon-sign.info/">FALCON</a> signature algorithm is 
+undergoing standardization by NIST. The information presented here is based on
+the 
+<a href="https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions">
+Post-Quantum Cryptography Round 3 Submission</a> information. This section will
+be updated when the NIST specification is issued.
         </p>
+        <p>
+FALCON is a lattice-based signature scheme. It stands for the following acronym:
+<u>Fa</u>st Fourier <u>l</u>attice-based <u>co</u>mpact signatures over 
+<u>N</u>TRU. FALCON defines parameter sets for two different claimed security
+strengths. The
+claimed security strengths, private key, public key, and signature sizes are
+summarized in [[[#FalconSummaryTable]]].
+        </p>
+        <table id="FalconSummaryTable" class="data numbered">
+          <caption><em>FALCON Signatures Summary, all sizes in bytes.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Security</th>
+              <th>Private Key</th>
+              <th>Public Key</th>
+              <th>Signature</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>FALCON-512</td>
+              <td>Category 1</td>
+              <td>1281</td>
+              <td>897</td>
+              <td>666</td>
+            </tr>
+            <tr>
+              <td>FALCON-1024</td>
+              <td>Category 5</td>
+              <td>2305</td>
+              <td>1793</td>
+              <td>1280</td>
+            </tr>
+          </tbody>
+        </table>
 
+        <p class="ednote">
+Private key size information from 
+<a href="https://openquantumsafe.org/liboqs/algorithms/sig/falcon.html">
+  openquantumsafe.org</a>.
+        </p>
+        <p>
+Supporting both the Universal RDF Dataset Canonicalization Algorithm [[RDF-CANON]],
+"`rdfc`", the JSON Canonicalization Scheme [[RFC8785]], "`jcs`", and a maximum
+security category of 1, leads to the
+family of FALCON cryptosuites given in [[[#FALCONSuitesTable]]].
+        </p>
+        <table id="FALCONSuitesTable" class="data numbered">
+          <caption><em>Supported FALCON Cryptosuites.</em> </caption>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Canonalization</th>
+              <th>Signature/Verification</th>
+              <th>Hash</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>`falcon512-rdfc-2024`</td>
+              <td>RDFC</td>
+              <td>FALCON-512</td>
+              <td>SHA-256</td>
+            </tr>
+            <tr>
+              <td>`falcon512-jcs-2024`</td>
+              <td>JCS</td>
+              <td>FALCON-512</td>
+              <td>SHA-256</td>
+            </tr>
+            <!-- 
+            <tr>
+              <td>`falcon1024-rdfc-2024`</td>
+              <td>RDFC</td>
+              <td>FALCON-1024</td>
+              <td>SHA-512</td>
+            </tr>
+            <tr>
+              <td>`falcon1024-jcs-2024`</td>
+              <td>JCS</td>
+              <td>FALCON-1024</td>
+              <td>SHA-512</td>
+            </tr> -->
+          </tbody>
+        </table>
         <section>
-          <h4>Create Proof (experimental-falcon-2025)</h4>
+          <h4>Create Proof (FALCON)</h4>
 
           <p>
 The following algorithm specifies how to create a [=data integrity proof=] given
-an <a>unsecured data document</a>. Required inputs are an
+an <a>unsecured data document</a> and a FALCON cryptosuite chosen from
+[[[#FALCONSuitesTable]]]. The choice of cryptosuite sets the values of |canonScheme|,
+|hashName|, |sigFunc|, and |verifyFunc| per [[[#FALCONSuitesTable]]], which are used
+in the algorithm below. Additional required inputs are an
 <a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
 options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
 is produced as output.
@@ -1467,27 +1549,28 @@ Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration]]] with
-|options| and `experimental-falcon-2025` passed as parameters.
+Section [[[#ProofConfigurationAlg]]] with
+|options|, the |cypherSuiteName|, |canonScheme|, and |hashName|
+passed as parameters.
             </li>
             <li>
-Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |options|, and
-`experimental-falcon-2025` passed as parameters.
+Let |transformedData| be the result of running the algorithm in Section
+[[[#TransformationAlg]]] with |unsecuredDocument|, |options|, the
+|cypherSuiteName|, |canonScheme|, and |hashName| passed as parameters.
             </li>
             <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing]]] with |transformedData| and |proofConfig|
+[[[#HashingAlg]]] with |transformedData|, |proofConfig|, and |hashName|
 passed as a parameters.
             </li>
             <li>
 Let |proofBytes| be the result of running the algorithm in Section
-[[[#proof-serialization-experimental-falcon-2025]]] with |hashData| and
-|options| passed as parameters.
+[[[#ProofSerializationAlg]]] with |hashData|, |options|, and
+|sigFunc| passed as parameters.
             </li>
             <li>
 Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
-base58-btc-encoded Multibase value</a> of the |proofBytes|.
+base64-url-encoded Multibase encoding</a> of the |proofBytes|.
             </li>
             <li>
 Return |proof| as the [=data integrity proof=].
@@ -1497,11 +1580,11 @@ Return |proof| as the [=data integrity proof=].
         </section>
 
         <section>
-          <h4>Verify Proof (experimental-falcon-2025)</h4>
+          <h4>Verify Proof (FALCON)</h4>
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
-an <a>secured data document</a>. Required input is a
+an <a>secured data document</a>. Required inputs are an
 <a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
 a <dfn>verification result</dfn>, which is a [=struct=] whose
 [=struct/items=] are:
@@ -1526,29 +1609,36 @@ Let |proofOptions| be a copy of |securedDocument|.|proof| with `proofValue`
 removed.
           </li>
           <li>
+Set |cryptosuiteName| to |securedDocument|.|proof|.|cryptosuite|,
+which must be one of those listed in [[[#FALCONSuitesTable]]].
+From |cryptosuiteName|, set the values of |canonScheme|, |hashName|,
+and |verifyFunc|, as found in [[[#MLSuitesTable]]].
+          </li>
+          <li>
 Let |proofBytes| be the
-<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base64-url
 value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
           <li>
-Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation"></a> with |unsecuredDocument|, |proofOptions|,
-and `experimental-falcon-2025` passed as parameters.
+Let |transformedData| be the result of running the algorithm in Section
+[[[#TransformationAlg]]] with |unsecuredDocument|,
+and |cypherSuiteName|,
+|canonScheme|, and |hashName| |proofOptions| passed as parameters.
           </li>
           <li>
 Let |proofConfig| be the result of running the algorithm in
-Section [[[#proof-configuration]]] with
-|options| and `experimental-falcon-2025` passed as parameters.
+Section [[[#ProofConfigurationAlg]]] with |options|, |cypherSuiteName|,
+|canonScheme|, and |hashName| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section
-[[[#hashing]]] with |transformedData| and |proofConfig|
+[[[#HashingAlg]]] with |transformedData|, |proofConfig|, and |hashName|
 passed as a parameters.
           </li>
           <li>
 Let |verified:boolean| be the result of running the algorithm in Section
-[[[#proof-verification-experimental-falcon-2025]]] algorithm on |hashData|,
-|proofBytes|, and |proofConfig|.
+[[[#ProofVerificationAlg]]] with |hashData|,
+|proofBytes|, |proofConfig|, and |verifyFunc| as parameters.
             </li>
             <li>
 Return a [=verification result=] with [=struct/items=]:
@@ -1557,91 +1647,12 @@ Return a [=verification result=] with [=struct/items=]:
                 <dd>|verified|</dd>
                 <dt>[=verifiedDocument=]</dt>
                 <dd>
-|unsecuredDocument| if |verified| is `true`; otherwise, <a data-cite="INFRA#nulls">Null</a></dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
               </dl>
             </li>
           </ol>
 
         </section>
-
-        <section>
-          <h4>Proof Serialization (experimental-falcon-2025)</h4>
-
-          <p>
-The following algorithm specifies how to serialize a digital signature from
-a set of cryptographic hash data. This
-algorithm is designed to be used in conjunction with the algorithms defined
-in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Algorithms</a>. Required inputs are
-cryptographic hash data (|hashData|) and
-<em>proof options</em> (|options|). The
-<em>proof options</em> MUST contain a type identifier for the
-<a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (|type|) and MAY contain a cryptosuite
-identifier (|cryptosuite|). A single <em>digital proof</em> value
-represented as series of bytes is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |privateKeyBytes| be the result of retrieving the
-private key bytes (or a signing interface enabling the use of the private key
-bytes) associated with the verification method identified by the
-|options|.|verificationMethod| value.
-            </li>
-            <li>
-Let |proofBytes| be the result of applying the Falcon
-Signature Algorithm [[FALCON]], with |hashData| as the data
-to be signed using the private key specified by |privateKeyBytes|.
-|proofBytes| will be exactly 666 bytes in size.
-            </li>
-            <li>
-Return |proofBytes| as the <em>digital proof</em>.
-            </li>
-          </ol>
-
-        </section>
-
-        <section>
-          <h4>Proof Verification (experimental-falcon-2025)</h4>
-
-          <p>
-The following algorithm specifies how to verify a digital signature from
-a set of cryptographic hash data. This
-algorithm is designed to be used in conjunction with the algorithms defined
-in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Algorithms</a>. Required inputs are
-cryptographic hash data (|hashData|),
-a digital signature (|proofBytes|), and
-proof options (|options|). A <em>verification result</em>
-represented as a boolean value is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Let |publicKeyBytes| be the result of retrieving the
-public key bytes associated with the
-|options|.|verificationMethod| value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieve Verification Method</a>.
-            </li>
-            <li>
-Let |verificationResult| be the result of applying the verification
-algorithm from the Falcon Digital Signature scheme [[FALCON]],
-with |hashData| as the data to be verified against the
-|proofBytes| using the public key specified by
-|publicKeyBytes|.
-            </li>
-            <li>
-Return |verificationResult| as the <em>verification result</em>.
-            </li>
-          </ol>
-
-        </section>
-      </section>
 
 
       <section id="SQISign_Cryptosuites">


### PR DESCRIPTION
This PR updates the FALCON and  SQIsign section to include information on claimed security strengths,  key sizes, and signature lengths.  It also update the corresponding algorithms to use the  "common  algorithms"  defined  in the specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/di-quantum-safe/pull/14.html" title="Last updated on Mar 31, 2026, 6:18 PM UTC (739307f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/di-quantum-safe/14/c9db5b0...Wind4Greg:739307f.html" title="Last updated on Mar 31, 2026, 6:18 PM UTC (739307f)">Diff</a>