### PR TITLE
Support for Efficient PQC Selective disclosure

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,8 +501,9 @@ of [[VC-DATA-INTEGRITY]] with the following restrictions.
 The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
-The `cryptosuite` property of the proof MUST be one of the following values from
-[[[#CryptosuiteTable]]].
+The `cryptosuite` property of the proof MUST be one of the values from
+[[[#CryptosuiteTable]]], below, or [[[#SDCryptosuiteTable]]] for selective 
+disclosure cryptosuites.
           </p>
 
           <table id="CryptosuiteTable" class="data numbered">
@@ -1941,7 +1942,7 @@ moved to an updated version of  [[VC-DATA-INTEGRITY]].
         </p>
         <p class="informative">
 Selective disclosure is enabled by the <em>issuer</em> creating a <em>base</em>
-proof as specified in section [[[#SD-Base]]]. The <em>issue</em> can specify 
+proof as specified in section [[[#SD-Base]]]. The <em>issuer</em> can specify 
 that certain claims are mandatory, i.e., have to be revealed to the 
 <em>verifier</em>. The <em>holder</em> on receiving the issued verifiable  
 credential with the <em>base</em> proof, uses it to create a related verifiable
@@ -2210,10 +2211,6 @@ cryptographic hash algorithm is that specified for signature algorithm in
             <li>
 Initialize |signature| to the result of digitally signing |toSign| using the
 private key associated with the base proof verification method.
-            </li>
-            <li>
-* Set the *proofValue* to the base64url CBOR encoded value of [signature, hmacKey, salts, 
-  saltedHashes, mandatoryPointers].
             </li>
             <li>
 Initialize a byte array, |proofValue|, that starts with the Quantum-Safe-SD 

--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@ Examples of all the `publicKeyMultibase` encodings defined in this specification
 can be found in appendix [[[#TestVectors]]].
           </p>
           <p class="ednote">
-Note*: The codes given in [[[#MultiKeyTable]]] for FALCON-512  and SQIsign-I are 
+Note*: The codes given in [[[#MultiKeyTable]]] for FALCON-512 and SQIsign-I are 
 preliminary and not currently registered with 
 <a href="https://github.com/multiformats/multicodec/blob/master/table.csv">
 multicodecs</a>. When these signature schemes are formalized by NIST or other 
@@ -1482,7 +1482,7 @@ Return a [=verification result=] with [=struct/items=]:
 
       <section id="Falcon_Cryptosuites">
         <h3>FALCON Cryptosuites</h3>
-        <p  class="ednote">
+        <p class="ednote">
 The [[FALCON]] signature algorithm is 
 undergoing standardization by NIST. The information presented here is based on
 the 
@@ -1704,7 +1704,7 @@ Return a [=verification result=] with [=struct/items=]:
 
       <section id="SQISign_Cryptosuites">
         <h3>SQIsign Cryptosuites</h3>
-        <p  class="ednote">
+        <p class="ednote">
 The <a href="https://sqisign.org/">SQIsign</a> signature algorithm has been 
 submitted to NIST. SQIsign aims for very compact key and signature sizes. 
 The information presented here is based on 
@@ -1909,6 +1909,65 @@ Return a [=verification result=] with [=struct/items=]:
               </dl>
             </li>
           </ol>
+
+        </section>
+      </section>
+      <section id="SelectiveDisclosure">
+        <h3>Selective Disclosure Cryptosuites for Quantum Safe Signatures</h3>
+        <p class="informative">
+This section provides algorithms for a relatively efficient approach to enabling
+<em>selective disclosure</em> of a verifiable credential protected by a quantum
+safe signature algorithm. This approach utilizes a single quantum safe signature
+while sharing additional information concerning the cryptographic hashes of the
+processed "claims". This contrasts with the approach taken in [[VC-DI-ECDSA]] 
+selective disclosure where a short signature is given for each processed  
+"claim" and no additional hashes are shared. This also contrasts with the 
+approach in [[VC-DI-BBS]] where the underlying signature scheme supports 
+multiple "claims" and only a single short signature is shared.
+        </p>
+        <p class="informative">
+In all the approaches to selective disclosure mentioned above the same core set
+of selective disclosure processing functions contained in [[VC-DI-ECDSA]] which
+enable flexibility and efficiency in implementations. The approach taken here is
+roughly more efficient when a signature is longer that twice the size of the
+corresponding hash for a given security level, e.g., 64 bytes for security 
+category 1 or 2.  From [[[#CryptosuiteTable]]] we can see that this condition is
+true for all signature algorithms currently considered in this specification.
+        </p>
+        <p class="ednote">
+The general selective disclosure functions in [[VC-DI-ECDSA]] are planned to be
+moved to an updated version of  [[VC-DATA-INTEGRITY]].
+        </p>
+
+        <section>
+          <h4>Create Selective Disclosure Base Proof</h4>
+        </section>
+
+        <section>
+          <h4>Base Proof Transformation Selective Disclosure</h4>
+        </section>
+
+        <section>
+          <h4>Base Proof Hashing Selective Disclosure</h4>
+        </section>
+
+        <section>
+          <h4>Base Proof Configuration Selective Disclosure</h4>
+        </section>
+
+        <section>
+          <h4>Base Proof Serialization Selective Disclosure</h4>
+        </section>
+
+        <section>
+          <h4>Add Derived Proof Selective Disclosure</h4>
+        </section>
+
+        <section>
+          <h4>Verify Derived Proof Selective Disclosure</h4>
+        </section>
+
+        <section>
 
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -2509,24 +2509,6 @@ were chosen to not conflict with values used by [[VC-DI-ECDSA]] and
 
         <section  id="SD-Verify-Derived">
           <h4>Verify Derived Proof Selective Disclosure</h4>
-<!-- Outline (to be removed when completed):
-* The verifier decodes the *proofValue* to obtain [signature, salts, saltedHashes, 
-  compressLabelMap, adjMandatoryIndexes, adjSelectiveIndexes].
-* From the *revealDocument* and the decoded proof value information they will compute 
-  the *proofHash* and the *mandatoryHash*. The mandatory and non-mandatory statements 
-  are recovered via the canonicalization algorithm, the compressLabelMap and the 
-  adjMandatoryIndexes.
-* The verifier verifies the signature against the hashed concatenation of (proofHash, 
-  mandatoryHash, salts, saltedHashes) with the signature algorithm.
-* For **every** non-mandatory statement they **must** check the hash value against 
-  the saltHash list of the corresponding salt value and non-mandatory statement. 
-  The *adjSelectiveIndexes* are used to find the proper entries in the salts and 
-  saltedHashes arrays. Only if all these checks and the previous check pass does 
-  the document verify. -->
-
-          <p class="ednote">
-TODO: From VC-DI-ECDSA, in progress of being updated.
-          </p>
           <p>
 The following algorithm attempts verification of an Quantum-Safe-SD derived
 proof. This algorithm is called by a verifier of an Quantum-Safe-SD protected
@@ -2541,49 +2523,54 @@ a [=verification result=]:
 Let |unsecuredDocument| be a copy of |document| with the `proof` value removed.
             </li>
             <li>
-Initialize |baseSignature|, |proofHash|, |publicKey|, |signatures|,
-|nonMandatory|, and |mandatoryHash| to the values associated with their property
-names in the object returned when calling the algorithm in Section
-[[[#createverifydata]]], passing the |document|, |proof|, and any
+Initialize |signature|, |proofHash|, |salts|, |saltedHashes|,
+|nonMandatory|, |mandatoryHash|, and |selectiveIndexes| to the values associated 
+with their property names in the object returned when calling the algorithm in 
+Section [[[#createverifydata]]], passing the |document|, |proof|, and any
 custom JSON-LD API options, such as a document loader.
             </li>
             <li>
-If the length of |signatures| does not match the length of |nonMandatory|,
+If the length of |salts| does not match the length of |saltedHashes|,
 an error MUST be raised and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>,
-indicating that the signature count does not match
-the non-mandatory message count.
+indicating that the salt count does not match
+the salted hashes count.
             </li>
             <li>
-Initialize |publicKeyBytes| to the public key bytes expressed in |publicKey|.
-Instructions on how to decode the public key value can be found in Section
-[[[#multikey]]].
+The values of the elements of the |selectiveIndexes| array must be between 0 and
+the length of the |salts| array minus one. If not, 
+an error MUST be raised and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>,
+indicating that the selective indexes are out of bounds.
             </li>
             <li>
-Initialize |toVerify| to the result of calling the algorithm in Setion
-[[[#serializesigndata]]], passing |proofHash|, |publicKey|, and
-|mandatoryHash|.
+Initialize |toVerify| to the byte  concatenation of the values: |proofHash|, 
+|mandatoryHash|, |salts|, and |saltedHashes| in that order with the array values
+themselves concatenated together.
             </li>
             <li>
 Initialize |verified| to true.
             </li>
             <li>
 Initialize |verificationCheck| be the result of applying the verification
-algorithm of the Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5],
-with |toVerify| as the data to be verified against the |baseSignature| using
-the public key specified by |publicKeyBytes|. If |verificationCheck| is
+algorithm of the appropriate Quantum Safe signature algorithms as indicated by 
+the "cryptosuite" property and [[[#SDCryptosuiteTable]]],
+with |toVerify| as the data to be verified against the |signature|. 
+If |verificationCheck| is
 `false`, set |verified| to false.
             </li>
             <li>
-For every entry (|index|, |signature|) in |signatures|, verify every signature
+For every entry (|nq|, |index|) in |nonMandatory|, verify the salted hash 
 for every selectively disclosed (non-mandatory) statement:
               <ol class="algorithm">
                 <li>
-Initialize |verificationCheck| to the result of applying the verification
-algorithm Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5], with
-the UTF-8 representation of the value at |index| of |nonMandatory| as the data
-to be verified against |signature| using the public key specified by
-|publicKeyBytes|.
+Let |computedHash| be the  hash of the concatenation of 
+|salts|[|selectiveIndexes|[index]] and |nq|.
+                </li>
+                <li>
+Initialize |verificationCheck| to the result of comparing the |computedHash| 
+with the value of  |saltedHashes|[|selectedIndexes|[index]].
+
                 </li>
                 <li>
 If |verificationCheck| is `false`, set |verified| to false.
@@ -2740,7 +2727,8 @@ length of the the |salts| and |saltedHashes| must be the same. The all elements
 of the |mandatoryIndexes| and |selectiveIndexes| should be in the range of 0 to
 the length of |salts|. There should not be repeated items in the 
 |mandatoryIndexes| and |selectiveIndexesArrays|. Also the elements of each of 
-these arrays should be increasing order.
+these arrays should be increasing order. Note that the minimal additional checks
+appear in [[[#SD-Verify-Derived]]].
           </p>
 
         </section>

--- a/index.html
+++ b/index.html
@@ -1986,22 +1986,6 @@ utilize the advanced features of [[RDF-CANON]].
           </table>
 
         <section id="SD-Base">
-<!-- Base Proof Outline (to be removed)
-
-* Transform via Canonicalize and Group:  This produces N-Quads (statements) that are in 
-  the two groups "mandatory" and  "non-mandatory". These are ordered.
-* Create random salts for every statement in non-mandatory. SD-JWT uses 128 bit (16 byte) 
-  random salts.
-* Compute a hash over all the  "mandatory" statements and call it the "mandatory_hash". 
-  Note that we *don't* salt any of the mandatory statements since they must be revealed.
-* Create a list of non-mandatory salted hashes by computing the hashes salts concatenated 
-  with the statements. Note that we can add dummy elements to the end of the non-mandatory 
-  list to hide the exact number of statements.
-* Use a quantum safe signature scheme to sign the hashed concatenation of 
-  (proofHash, mandatoryHash, salts, saltedHashes).
-* Set the *proofValue* to the base64url CBOR encoded value of [signature, hmacKey, salts, 
-  saltedHashes, mandatoryPointers].
--->
           <h4>Create Selective Disclosure Base Proof</h4>
 
           <p>
@@ -2123,15 +2107,6 @@ and `hmacKey` set to |hmacKey|.
 
         <section>
           <h4>Base Proof Hashing Selective Disclosure</h4>
-<!-- 
-* Create random salts for every statement in non-mandatory. SD-JWT uses 128 bit (16 byte) 
-  random salts.
-* Compute a hash over all the  "mandatory" statements and call it the "mandatory_hash". 
-  Note that we *don't* salt any of the mandatory statements since they must be revealed.
-* Create a list of non-mandatory salted hashes by computing the hashes salts concatenated 
-  with the statements. Note that we can add dummy elements to the end of the non-mandatory 
-  list to hide the exact number of statements.           
--->
 
           <p>
 The following algorithm specifies how to cryptographically hash a
@@ -2170,7 +2145,7 @@ object.
             </li>
             <li>
 Initialize |salts| as an empty array. For each |nonMandatory| item in the 
-|transformedDocument| create a true cryptographically secure random number of 
+|transformedDocument| create a cryptographically secure random number of 
 byte length half the size of the hash length, e.g., for security category 1 or 2
 using SHA-256 the length of each salt would be 16 bytes.
             </li>
@@ -2189,17 +2164,15 @@ object.
 Return |hashData| as <em>hash data</em>.
             </li>
           </ol>
-
+          <p class="ednote">
+To do: provide background on <em>cryptographic random number generation</em> in the 
+security considerations section. For example cite appropriate references such as
+NIST SP-800-90A,B,C documents and/or BSI AIS 20 and AIS 31 documents.
+          </p>
         </section>
 
         <section>
           <h4>Base Proof Serialization Selective Disclosure</h4>
-<!-- 
-* Use a quantum safe signature scheme to sign the hashed concatenation of 
-  (proofHash, mandatoryHash, salts, saltedHashes).
-* Set the *proofValue* to the base64url CBOR encoded value of [signature, hmacKey, salts, 
-  saltedHashes, mandatoryPointers].
--->
 
           <p>
 The following algorithm specifies how to create a base proof; called by an
@@ -2276,6 +2249,262 @@ currently tentative.
 
         <section  id="SD-Derived">
           <h4>Add Derived Proof Selective Disclosure</h4>
+
+          <p>
+The following algorithm creates a selective disclosure derived proof; called by
+a holder of an Quantum-Safe-SD protected [=verifiable credential=].
+The derived proof is to be given to the [=verifier=]. The inputs include a
+JSON-LD document (|document|), Quantum-Safe-SD base proof
+(|proof|), an array of JSON pointers to use to selectively disclose
+statements (|selectivePointers|), and any custom JSON-LD API options,
+such as a document loader. A single <em>selectively revealed document</em>
+value, represented as an object, is produced as output.
+          </p>
+          <ol>
+            <li>
+Initialize |signature|, |salts|, |saltedHashes|, |labelMap|,
+|mandatoryIndexes|, |selectiveIndexes| and |revealDocument| to the values 
+associated with their
+property names in the object returned when calling the algorithm in
+Section [[[#Derived-Create-Disclosure-Data]]], passing the |document|, |proof|,
+|selectivePointers|, and any custom JSON-LD API options, such as a document
+loader.
+            </li>
+            <li>
+Initialize |newProof| to a shallow copy of |proof|.
+            </li>
+
+            <li>
+Replace |proofValue| in |newProof| with the result of calling the algorithm
+in Section [[[#SD-Derived-Serialize-Proof]]], passing
+|signature|, |publicKey|, |signatures|, |labelMap|, and |mandatoryIndexes|.
+            </li>
+            <li>
+Set the value of the "proof" property in |revealDocument| to |newProof|.
+            </li>
+            <li>
+Return |revealDocument| as the <em>selectively revealed document</em>.
+            </li>
+          </ol>
+
+        </section>
+        <section id="Derived-Create-Disclosure-Data">
+          <h4>Derived Proof: Create Disclosure Data</h4>
+
+          <p>
+The following algorithm creates data to be used to generate a derived proof. The
+inputs include a JSON-LD document (|document|), an Quantum-Safe-SD base proof
+(|proof|), an array of JSON pointers to use to selectively disclose
+statements (|selectivePointers|), and any custom JSON-LD API options,
+such as a document loader). A single object, <em>disclosure data</em>, is
+produced as output, which contains the "signature", "salts",
+"saltedHashes", "labelMap", "mandatoryIndexes", "selectiveIndexes" and
+"revealDocument" fields.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize |signature|, |hmacKey|, |salts|, |saltedHashes|, and
+|mandatoryPointers| to the values of the associated properties in the object
+returned when calling the algorithm in Section
+[[[#Derived-Parse-Base-Proof]]], passing the |proofValue| from |proof|.
+            </li>
+            <li>
+Initialize |hmac| to an HMAC API using |hmacKey|. The HMAC uses the same hash
+algorithm used in the signature algorithm, i.e., SHA-256 for a security category
+1 or 2 algorithm.
+            </li>
+            <li>
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#createhmacidlabelmapfunction">
+Section 3.4.4 createHmacIdLabelMapFunction</a> of [[VC-DI-ECDSA]], 
+passing |hmac|.
+            </li>
+            <li>
+Initialize |combinedPointers| to the concatenation of |mandatoryPointers|
+and |selectivePointers|.
+            </li>
+            <li>
+Initialize |groupDefinitions| to a map with the following entries: key of
+the string `"mandatory"` and value of |mandatoryPointers|, key of the string
+`"selective"` and value of |selectivePointers|, and key of the string `"combined"`
+and value of |combinedPointers|.
+            </li>
+            <li>
+Initialize |groups| and |labelMap| to their associated values in the result
+of calling the algorithm in 
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#canonicalizeandgroup">Section 3.3.16
+canonicalizeAndGroup</a> of the [[VC-DI-ECDSA]] specification,
+passing |document|,
+|labelMapFactoryFunction|, |groupDefinitions|, and any custom
+JSON-LD API options as parameters. Note: This step transforms the document into
+an array of canonical N-Quad strings with pseudorandom blank node identifiers
+based on |hmac|, and groups the N-Quad strings according to selections based on
+JSON pointers.
+            </li>
+            <li>
+Compute the mandatory indexes. Initialize |relativeIndex| to zero.
+            </li>
+            <li>
+Initialize |mandatoryIndexes| to an empty array.
+            </li>
+            <li>
+For each |absoluteIndex| in the keys in |groups|.|combined|.|matching|, convert
+the absolute index of any <em>mandatory</em> N-Quad to an index relative to the 
+combined output that is to be revealed:
+              <ol class="algorithm">
+                <li>
+If |groups|.|mandatory|.|matching| has |absoluteIndex| as a key, then append
+|relativeIndex| to |mandatoryIndexes|.
+                </li>
+                <li>
+Increment |relativeIndex|.
+                </li>
+              </ol>
+            </li>
+            <li>
+Compute the selective indexes. Initialize |relativeIndex| to zero.
+            </li>
+            <li>
+Initialize |selectiveIndexes| to an empty array.
+            </li>
+            <li>
+For each |absoluteIndex| in the keys in |groups|.|combined|.|matching|, convert
+the absolute index of any <em>selective</em> N-Quad to an index relative to the 
+combined output that is to be revealed:
+              <ol class="algorithm">
+                <li>
+If |groups|.|selective|.|matching| has |absoluteIndex| as a key, then append
+|relativeIndex| to |selectiveIndexes|.
+                </li>
+                <li>
+Increment |relativeIndex|.
+                </li>
+              </ol>
+            </li>
+            <li>
+Initialize |revealDocument| to the result of the calling the algorithm in 
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#selectjsonld">3.4.13 selectJsonLd
+</a> of [[VC-DI-ECDSA]],
+passing |document|, and |combinedPointers| as |pointers|.
+            </li>
+            <li>
+Run the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] on
+the joined |combinedGroup.deskolemizedNQuads|, passing any custom
+options, and get the canonical bnode identifier map, |canonicalIdMap|.
+Note: This map includes the canonical blank node identifiers that a verifier
+will produce when they canonicalize the reveal document.
+            </li>
+            <li>
+Initialize |verifierLabelMap| to an empty map. This map will map
+the canonical blank node identifiers the verifier will produce when they
+canonicalize the revealed document to the blank node identifiers that were
+originally signed in the base proof.
+            </li>
+            <li>
+For each key (|inputLabel|) and value (|verifierLabel|) in |canonicalIdMap|:
+              <ol class="algorithm">
+                <li>
+Add an entry to |verifierLabelMap| using |verifierLabel| as the key and the
+value associated with |inputLabel| as a key in |labelMap| as the value.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return an object with properties matching |signature|, |salts|,
+|saltedHashes|, `verifierLabelMap` for |labelMap|, |mandatoryIndexes|, 
+|selectiveIndexes|, and |revealDocument|.
+            </li>
+          </ol>
+
+        </section>
+
+        <section id="Derived-Parse-Base-Proof">
+          <h4>Derived Proof: Parse Base</h4>
+          <p>
+The following algorithm parses the components of an Quantum Safe selective
+disclosure base proof value. The required inputs are a proof value
+(|proofValue|). A single object <em>parsed base proof</em>, containing
+five elements, using the names `signature`, `hmacKey`, `salts`
+`saltedHashes`, and `mandatoryPointers`, is produced  as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If the |proofValue| string does not start with `u`, indicating that it is
+a multibase-base64url-no-pad-encoded value, an error MUST be raised
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
+            </li>
+            <li>
+Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
+substring after the leading `u` in |proofValue|.
+            </li>
+            <li>
+If the |decodedProofValue| does not start with the Quantum-Safe-SD base proof
+header bytes `0xd9`, `0x5d`, and `0x10`, an error MUST be raised and SHOULD
+convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
+            </li>
+            <li>
+Initialize |components| to an array that is the result of CBOR-decoding the
+bytes that follow the three-byte Quantum-Safe-SD base proof header. Confirm that 
+the result is an array of five elements.
+            </li>
+            <li>
+Return an object with properties set to the five elements, using the names
+`signature`, `hmacKey`, `salts`, `saltedHashes`, and `mandatoryPointers`,
+respectively.
+            </li>
+          </ol>
+
+        </section>
+
+        <section id="SD-Derived-Serialize-Proof">
+          <h4>Serialize Derived Proof Value</h4>
+
+          <p>
+The following algorithm serializes a Quantum-Safe-SD derived proof value. 
+The required inputs are a base signature (|signature|), an array of salts 
+(|salts|), an array of salted  hashes (|saltedHashes|), a label map 
+(|labelMap|), an array of mandatory indexes (|mandatoryIndexes|). and an array 
+of selective indexes (|selectiveIndexes|). A single <em>derived proof</em> 
+value, serialized as a byte string, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize |compressedLabelMap| to the result of calling the algorithm in
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#compresslabelmap">Section 3.5.5 
+compressLabelMap</a>  of  [[VC-DI-ECDSA]], passing |labelMap| as the parameter.
+            </li>
+            <li>
+Initialize a byte array, |proofValue|, that starts with the Quantum-Safe-SD 
+disclosure proof header bytes `0xd9`, `0x5d`, and `0x11`.
+            </li>
+            <li>
+Initialize |components| to an array with six elements containing the values of:
+|signature|, |salts|, |saltedHashes|, |compressedLabelMap|, |mandatoryIndexes|,
+|selectiveIndexes|.
+            </li>
+            <li>
+CBOR-encode |components| per [[RFC8949]] where CBOR tagging MUST NOT be used on
+any of the |components|. Append the produced encoded value to |proofValue|.
+            </li>
+            <li>
+Return the <em>derived proof</em> as a string with the
+base64url-no-pad-encoding of |proofValue| as described in the
+<a data-cite="CID#multibase-0">
+Multibase section</a> of [[[CID]]]. That is, return a string
+starting with "`u`" and ending with the base64url-no-pad-encoded value of
+|proofValue|.
+            </li>
+          </ol>
+          <p class="ednote">
+The Quantum-Safe-SD disclosure proof header bytes `0xd9`, `0x5d`, and `0x11` 
+were chosen to not conflict with values used by [[VC-DI-ECDSA]] and 
+[[VC-DI-BBS]] and are tentative.
+          </p>
         </section>
 
         <section  id="SD-Verify-Derived">

--- a/index.html
+++ b/index.html
@@ -1919,17 +1919,18 @@ This section provides algorithms for a relatively efficient approach to enabling
 <em>selective disclosure</em> of a verifiable credential protected by a quantum
 safe signature algorithm. This approach utilizes a single quantum safe signature
 while sharing additional information concerning the cryptographic hashes of the
-processed "claims". This contrasts with the approach taken in [[VC-DI-ECDSA]] 
+processed <em>claims</em>. This contrasts with the approach taken in [[VC-DI-ECDSA]] 
 selective disclosure where a short signature is given for each processed  
-"claim" and no additional hashes are shared. This also contrasts with the 
+<em>claim</em> and no additional hashes are shared. This also contrasts with the 
 approach in [[VC-DI-BBS]] where the underlying signature scheme supports 
-multiple "claims" and only a single short signature is shared.
+multiple <em>claims</em> and only a single short signature is shared.
         </p>
         <p class="informative">
 In all the approaches to selective disclosure mentioned above the same core set
-of selective disclosure processing functions contained in [[VC-DI-ECDSA]] which
-enable flexibility and efficiency in implementations. The approach taken here is
-roughly more efficient when a signature is longer that twice the size of the
+of selective disclosure processing functions contained in [[VC-DI-ECDSA]] are 
+utilized which enables flexibility and efficiency in implementations. 
+The approach taken here is roughly more efficient when a signature is longer 
+than twice the size of the
 corresponding hash for a given security level, e.g., 64 bytes for security 
 category 1 or 2.  From [[[#CryptosuiteTable]]] we can see that this condition is
 true for all signature algorithms currently considered in this specification.
@@ -1938,8 +1939,53 @@ true for all signature algorithms currently considered in this specification.
 The general selective disclosure functions in [[VC-DI-ECDSA]] are planned to be
 moved to an updated version of  [[VC-DATA-INTEGRITY]].
         </p>
+        <p class="informative">
+Selective disclosure is enabled by the <em>issuer</em> creating a <em>base</em>
+proof as specified in section [[[#SD-Base]]]. The <em>issue</em> can specify 
+that certain claims are mandatory, i.e., have to be revealed to the 
+<em>verifier</em>. The <em>holder</em> on receiving the issued verifiable  
+credential with the <em>base</em> proof, uses it to create a related verifiable
+credential whose <em>claims</em> are a selected subset of <em>claims</em> from
+the received document. This is done with the algorithm of section 
+[[[#SD-Derived]]]. Finally the <em>verifier</em> uses the algorithm of section 
+[[[#SD-Verify-Derived]]] to verify the selectively disclosed verifiable 
+credential.
+        </p>
+The selective disclosure cryptosuites defined in this specification are  listed
+in  [[[#SDCryptosuiteTable]]]. Note that all selective disclosure cryptosuites 
+utilize the advanced features of [[RDF-CANON]].
+        <p>
 
-        <section>
+        </p>
+        <table id="SDCryptosuiteTable" class="data numbered">
+            <caption><em>Cryptosuites.</em> </caption>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Signature Algorithm</th>
+                <th>Signature Length</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>`mldsa44-sd-2024`</td>
+                <td>ML-DSA-44</td>
+                <td>2420</td>
+              </tr>
+              <tr>
+                <td>`slhdsa128-sd-2024`</td>
+                <td>SLH-DSA-SHA2-128s</td>
+                <td>7856</td>
+              </tr>
+              <tr>
+                <td>`falcon512-sd-2024`</td>
+                <td>FALCON-512</td>
+                <td>666</td>
+              </tr>
+            </tbody>
+          </table>
+
+        <section id="SD-Base">
           <h4>Create Selective Disclosure Base Proof</h4>
         </section>
 
@@ -1959,11 +2005,11 @@ moved to an updated version of  [[VC-DATA-INTEGRITY]].
           <h4>Base Proof Serialization Selective Disclosure</h4>
         </section>
 
-        <section>
+        <section  id="SD-Derived">
           <h4>Add Derived Proof Selective Disclosure</h4>
         </section>
 
-        <section>
+        <section  id="SD-Verify-Derived">
           <h4>Verify Derived Proof Selective Disclosure</h4>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -1986,23 +1986,292 @@ utilize the advanced features of [[RDF-CANON]].
           </table>
 
         <section id="SD-Base">
+<!-- Base Proof Outline (to be removed)
+
+* Transform via Canonicalize and Group:  This produces N-Quads (statements) that are in 
+  the two groups "mandatory" and  "non-mandatory". These are ordered.
+* Create random salts for every statement in non-mandatory. SD-JWT uses 128 bit (16 byte) 
+  random salts.
+* Compute a hash over all the  "mandatory" statements and call it the "mandatory_hash". 
+  Note that we *don't* salt any of the mandatory statements since they must be revealed.
+* Create a list of non-mandatory salted hashes by computing the hashes salts concatenated 
+  with the statements. Note that we can add dummy elements to the end of the non-mandatory 
+  list to hide the exact number of statements.
+* Use a quantum safe signature scheme to sign the hashed concatenation of 
+  (proofHash, mandatoryHash, salts, saltedHashes).
+* Set the *proofValue* to the base64url CBOR encoded value of [signature, hmacKey, salts, 
+  saltedHashes, mandatoryPointers].
+-->
           <h4>Create Selective Disclosure Base Proof</h4>
+
+          <p>
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proof| be a clone of the proof options, |options|.
+            </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section [[[#ProofConfigurationAlg]]] with
+|options| passed as a parameter.
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#base-proof-transformation-selective-disclosure"></a> with 
+|unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
+            </li>
+            <li>
+Let |hashData| be the result of running the algorithm in Section
+[[[#base-proof-hashing-selective-disclosure]]] with |transformedData| and |proofConfig|
+passed as a parameters.
+            </li>
+            <li>
+Let |proofBytes| be the result of running the algorithm in Section
+[[[#base-proof-serialization-selective-disclosure]]] with |hashData| and
+|options| passed as parameters.
+            </li>
+            <li>
+Let |proof|.|proofValue| be a <a data-cite="CID#multibase-0">
+base64-url-encoded Multibase value</a> of the |proofBytes|.
+            </li>
+            <li>
+Return |proof| as the [=data integrity proof=].
+            </li>
+          </ol>
         </section>
 
         <section>
           <h4>Base Proof Transformation Selective Disclosure</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section [[[#base-proof-hashing-selective-disclosure]]].
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (|unsecuredDocument|) and
+transformation options (|options|). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|), a cryptosuite
+identifier (|cryptosuite|), and a verification method
+(|verificationMethod|). The transformation options MUST contain an
+array of mandatory JSON pointers (|mandatoryPointers|) and MAY contain
+additional options, such as a JSON-LD document loader. A <em>transformed data
+document</em> is produced as output. Whenever this algorithm encodes strings, it
+MUST use UTF-8 encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize |hmac| to an HMAC API using a locally generated and exportable HMAC
+key. The HMAC uses the same hash algorithm used in the signature algorithm,
+which is detected via the |verificationMethod| provided to the
+function, i.e., SHA-256 for a security category 1 or 2 signature algorithm. 
+Per the recommendations of
+[[RFC2104]], the HMAC key MUST be the same length as the digest size; 
+for SHA-256,
+this is 256 bits or 32 bytes.
+            </li>
+            <li>
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#createhmacidlabelmapfunction">
+Section 3.4.4 createHmacIdLabelMapFunction</a> of [[VC-DI-ECDSA]], 
+passing |hmac|.
+            </li>
+            <li>
+Initialize |groupDefinitions| to a map with an entry with a key of the string
+"mandatory" and a value of |mandatoryPointers|.
+            </li>
+            <li>
+Initialize |groups| to the result of calling the algorithm in
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#canonicalizeandgroup">Section 3.3.16
+canonicalizeAndGroup</a> of the [[VC-DI-ECDSA]] specification,
+passing |labelMapFactoryFunction|,
+|groupDefinitions|, |unsecuredDocument| as |document|, and any custom JSON-LD
+API options. Note: This step transforms the document into an array of canonical
+N-Quads with pseudorandom blank node identifiers based on |hmac|, and groups
+the N-Quad strings according to selections based on JSON pointers.
+            </li>
+            <li>
+Initialize |mandatory| to the values in the |groups|.|mandatory|.|matching| map.
+            </li>
+            <li>
+Initialize |nonMandatory| to the values in the
+|groups|.|mandatory|.|nonMatching| map.
+            </li>
+            <li>
+Initialize |hmacKey| to the result of exporting the HMAC key from |hmac|.
+            </li>
+            <li>
+Return an object with `mandatoryPointers` set to |mandatoryPointers|,
+`mandatory` set to |mandatory|, `nonMandatory` set to |nonMandatory|,
+and `hmacKey` set to |hmacKey|.
+            </li>
+          </ol>
         </section>
 
         <section>
           <h4>Base Proof Hashing Selective Disclosure</h4>
-        </section>
+<!-- 
+* Create random salts for every statement in non-mandatory. SD-JWT uses 128 bit (16 byte) 
+  random salts.
+* Compute a hash over all the  "mandatory" statements and call it the "mandatory_hash". 
+  Note that we *don't* salt any of the mandatory statements since they must be revealed.
+* Create a list of non-mandatory salted hashes by computing the hashes salts concatenated 
+  with the statements. Note that we can add dummy elements to the end of the non-mandatory 
+  list to hide the exact number of statements.           
+-->
 
-        <section>
-          <h4>Base Proof Configuration Selective Disclosure</h4>
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section [[[#base-proof-serialization-selective-disclosure]]].
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(|transformedDocument|) and <em>canonical proof configuration</em>
+(|canonicalProofConfig|). A <em>hash data</em> value represented
+as an object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize |proofHash| to the result of calling the RDF Dataset Canonicalization
+algorithm [[RDF-CANON]] on |canonicalProofConfig| and then cryptographically
+hashing the result using the same hash that is used by the signature algorithm,
+i.e., SHA-256 for a security category 1 or 2 algorithms. Note: This step can 
+be performed in parallel;
+it only needs to be completed before this algorithm terminates as the result is
+part of the return value.
+            </li>
+            <li>
+Initialize |mandatoryHash| to the result of calling the the algorithm in 
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#hashmandatorynquads">Section 3.3.17
+hashMandatoryNQuads</a> of the [[VC-DI-ECDSA]] specification,
+passing |transformedDocument|.|mandatory|.
+            </li>
+            <li>
+Initialize |hashData| as a deep copy of |transformedDocument| and
+add |proofHash| as `proofHash` and |mandatoryHash| as `mandatoryHash` to that
+object.
+            </li>
+            <li>
+Initialize |salts| as an empty array. For each |nonMandatory| item in the 
+|transformedDocument| create a true cryptographically secure random number of 
+byte length half the size of the hash length, e.g., for security category 1 or 2
+using SHA-256 the length of each salt would be 16 bytes.
+            </li>
+            <li>
+Initialize |saltedHashes| as an empty array. For each |nonMandatory| item in the 
+|transformedDocument| compute the appropriate hash (SHA-256 for security 
+category 1 or 2 signature algorithms) over the concatenation of each |salt| and
+its corresponding |nonMandatory| item. Add this hash value to the |saltedHashes|
+array.
+            </li>
+            <li>
+Add |salts| as `salts` and |saltedHashes| as  `saltedHashes` to  the |hashData|
+object.
+            </li>
+            <li>
+Return |hashData| as <em>hash data</em>.
+            </li>
+          </ol>
+
         </section>
 
         <section>
           <h4>Base Proof Serialization Selective Disclosure</h4>
+<!-- 
+* Use a quantum safe signature scheme to sign the hashed concatenation of 
+  (proofHash, mandatoryHash, salts, saltedHashes).
+* Set the *proofValue* to the base64url CBOR encoded value of [signature, hmacKey, salts, 
+  saltedHashes, mandatoryPointers].
+-->
+
+          <p>
+The following algorithm specifies how to create a base proof; called by an
+issuer of an Quantum-Safe-SD-protected Verifiable Credential. 
+The base proof is to be
+given only to the holder, who is responsible for generating a derived proof from
+it, exposing only selectively disclosed details in the proof to a verifier. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (|hashData|) and
+<em>proof options</em> (|options|). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (|type|) and MAY contain a cryptosuite
+identifier (|cryptosuite|). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize |proofHash|, |mandatoryPointers|, |mandatoryHash|, |salts|, 
+|saltedHashes|,
+and |hmacKey| to the values associated with their property names
+|hashData|.
+            </li>
+            <li>
+Initialize |toSign| the hash of the concatenation of |proofHash|, 
+|mandatoryHash|, |salts|,
+and |saltedHashes| where the order of the concatenation MUST be followed. The
+cryptographic hash algorithm is that specified for signature algorithm in 
+[[[#HashSigTable]]], e.g., SHA-256 for a security category 1 or 2 algorithms.
+            </li>
+            <li>
+Initialize |signature| to the result of digitally signing |toSign| using the
+private key associated with the base proof verification method.
+            </li>
+            <li>
+* Set the *proofValue* to the base64url CBOR encoded value of [signature, hmacKey, salts, 
+  saltedHashes, mandatoryPointers].
+            </li>
+            <li>
+Initialize a byte array, |proofValue|, that starts with the Quantum-Safe-SD 
+base proof header bytes 0xd9, 0x5d, and 0x10.
+            </li>
+            <li>
+Initialize |components| to an array with five elements containing the values of:
+|signature|, |hmacKey|, |salts|, |saltedHashes|, and |mandatoryPointers|.
+            </li>
+            <li>
+CBOR-encode |components| per [[RFC8949]] where CBOR tagging MUST NOT be used on
+any of the |components|. Append the produced encoded value to |proofValue|.
+            </li>
+            <li>
+Initialize |baseProof| to a string with the Multibase
+base64url-no-pad-encoding of |proofValue| as described in the
+<a data-cite="CID#multibase-0">
+Multibase section</a> of [[[CID]]]. That is, return a string
+starting with "`u`" and ending with the base64url-no-pad-encoded value of
+|proofValue|.
+            </li>
+            <li>
+Return |baseProof| as <em>base proof</em>.
+            </li>
+          </ol>
+
+          <p class="ednote">
+The Quantum-Safe-SD base proof header bytes 0xd9, 0x5d, and 0x10 were chosen 
+to not collide with any of the [[VC-DI-ECDSA]] or [[VC-DI-BBS]] values. They are
+currently tentative.
+          </p>
         </section>
 
         <section  id="SD-Derived">

--- a/index.html
+++ b/index.html
@@ -2509,11 +2509,250 @@ were chosen to not conflict with values used by [[VC-DI-ECDSA]] and
 
         <section  id="SD-Verify-Derived">
           <h4>Verify Derived Proof Selective Disclosure</h4>
+<!-- Outline (to be removed when completed):
+* The verifier decodes the *proofValue* to obtain [signature, salts, saltedHashes, 
+  compressLabelMap, adjMandatoryIndexes, adjSelectiveIndexes].
+* From the *revealDocument* and the decoded proof value information they will compute 
+  the *proofHash* and the *mandatoryHash*. The mandatory and non-mandatory statements 
+  are recovered via the canonicalization algorithm, the compressLabelMap and the 
+  adjMandatoryIndexes.
+* The verifier verifies the signature against the hashed concatenation of (proofHash, 
+  mandatoryHash, salts, saltedHashes) with the signature algorithm.
+* For **every** non-mandatory statement they **must** check the hash value against 
+  the saltHash list of the corresponding salt value and non-mandatory statement. 
+  The *adjSelectiveIndexes* are used to find the proper entries in the salts and 
+  saltedHashes arrays. Only if all these checks and the previous check pass does 
+  the document verify. -->
+
+          <p class="ednote">
+TODO: From VC-DI-ECDSA, in progress of being updated.
+          </p>
+          <p>
+The following algorithm attempts verification of an Quantum-Safe-SD derived
+proof. This algorithm is called by a verifier of an Quantum-Safe-SD protected
+[=verifiable credential=]. The inputs include a JSON-LD document
+(|document|), a Quantum-Safe-SD disclosure proof (|proof|), and any
+custom JSON-LD API options, such as a document loader. This algorithm returns
+a [=verification result=]:
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let |unsecuredDocument| be a copy of |document| with the `proof` value removed.
+            </li>
+            <li>
+Initialize |baseSignature|, |proofHash|, |publicKey|, |signatures|,
+|nonMandatory|, and |mandatoryHash| to the values associated with their property
+names in the object returned when calling the algorithm in Section
+[[[#createverifydata]]], passing the |document|, |proof|, and any
+custom JSON-LD API options, such as a document loader.
+            </li>
+            <li>
+If the length of |signatures| does not match the length of |nonMandatory|,
+an error MUST be raised and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>,
+indicating that the signature count does not match
+the non-mandatory message count.
+            </li>
+            <li>
+Initialize |publicKeyBytes| to the public key bytes expressed in |publicKey|.
+Instructions on how to decode the public key value can be found in Section
+[[[#multikey]]].
+            </li>
+            <li>
+Initialize |toVerify| to the result of calling the algorithm in Setion
+[[[#serializesigndata]]], passing |proofHash|, |publicKey|, and
+|mandatoryHash|.
+            </li>
+            <li>
+Initialize |verified| to true.
+            </li>
+            <li>
+Initialize |verificationCheck| be the result of applying the verification
+algorithm of the Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5],
+with |toVerify| as the data to be verified against the |baseSignature| using
+the public key specified by |publicKeyBytes|. If |verificationCheck| is
+`false`, set |verified| to false.
+            </li>
+            <li>
+For every entry (|index|, |signature|) in |signatures|, verify every signature
+for every selectively disclosed (non-mandatory) statement:
+              <ol class="algorithm">
+                <li>
+Initialize |verificationCheck| to the result of applying the verification
+algorithm Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5], with
+the UTF-8 representation of the value at |index| of |nonMandatory| as the data
+to be verified against |signature| using the public key specified by
+|publicKeyBytes|.
+                </li>
+                <li>
+If |verificationCheck| is `false`, set |verified| to false.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>The value of |verified|</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a
+data-cite="INFRA#nulls">Null</a>
+                </dd>
+              </dl>
+            </li>
+          </ol>
+
         </section>
 
-        <section>
+        <section id="createverifydata">
+          <h4>Create Verify Data</h4>
+
+          <p class="ednote">
+<strong>Work in Progress</strong>. Updating from [[VC-DI-ECDSA]] version.         
+          </p>
+<!-- 
+const createVerifyData = {
+  signature: bytesToHex(signature),
+  proofHash: bytesToHex(proofHash),
+  salts: salts.map(s => bytesToHex(s)),
+  saltedHashes: saltedHashes.map(sh => bytesToHex(sh)),
+  nonMandatory,
+  mandatoryHash: bytesToHex(mandatoryHash)
+}           -->
+          <p>
+The following algorithm creates the data needed to perform verification of an
+Quantum-Safe-SD protected [=verifiable credential=]. The inputs include a JSON-LD
+document (|document|), an Quantum-Safe-SD disclosure proof (|proof|),
+and any custom JSON-LD API options, such as a document loader. A single
+<em>verify data</em> object value is produced as output containing the following
+fields: "signature", "proofHash", "salts", "saltedHashes", "nonMandatory",
+and "mandatoryHash".
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize |proofHash| to the result of perform RDF Dataset Canonicalization
+[[RDF-CANON]] on the proof options. The hash used is the same as the one used in
+the signature algorithm, i.e., SHA-256 for security category 1 or 2 algorithms. 
+Note: This step can be
+performed in parallel; it only needs to be completed before this algorithm needs
+to use the |proofHash| value.
+            </li>
+            <li>
+Initialize |signature|, |salts|, |saltedHashes|, |labelMap|, |mandatoryIndexes|, 
+and |selectiveIndexes| to the values associated with their property names in the
+object returned when calling the algorithm in Section
+[[[#parsederivedproofvalue]]], passing |proofValue| from |proof|.
+            </li>
+            <!-- STOPPED HERE to work on parsing... -->
+            <li>
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+Section [[[#createlabelmapfunction]]].
+            </li>
+            <li>
+Initialize |nquads| to the result of calling the algorithm of section
+[[[#labelreplacementcanonicalizejsonld]]], passing |document|,
+|labelMapFactoryFunction|, and any custom
+JSON-LD API options. Note: This step transforms the document into an array of
+canonical N-Quads with pseudorandom blank node identifiers based on |labelMap|.
+            </li>
+            <li>
+Initialize |mandatory| to an empty array.
+            </li>
+            <li>
+Initialize |nonMandatory| to an empty array.
+            </li>
+            <li>
+For each entry (|index|, |nq|) in |nquads|, separate the N-Quads into mandatory
+and non-mandatory categories:
+              <ol class="algorithm">
+                <li>
+If |mandatoryIndexes| includes |index|, add |nq| to |mandatory|.
+                </li>
+                <li>
+Otherwise, add |nq| to |nonMandatory|.
+                </li>
+              </ol>
+            </li>
+            <li>
+Initialize |mandatoryHash| to the result of calling the "hashMandatory"
+primitive, passing |mandatory|.
+            </li>
+            <li>
+Return an object with properties matching |baseSignature|, |proofHash|,
+|publicKey|, |signatures|, |nonMandatory|, and |mandatoryHash|.
+            </li>
+          </ol>
 
         </section>
+
+        <section id="parsederivedproofvalue">
+          <h4>Parse Derived Proof Value</h4>
+
+          <p>
+The following algorithm parses the components of the derived proof value.
+The required input is a derived proof value (|proofValue|).
+A single <em>derived proof value</em> value object is produced as output, which
+contains a set to six elements, using the names "signature", "salts",
+"saltedHashes", "labelMap", "mandatoryIndexes", and "selectiveIndexes".
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If the |proofValue| string does not start with `u`, indicating that it is a
+multibase-base64url-no-pad-encoded value, an error MUST be raised
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
+            </li>
+            <li>
+Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
+substring after the leading `u` in |proofValue|.
+            </li>
+            <li>
+If the |decodedProofValue| does not start with the Quantum-Safe-SD disclosure proof
+header bytes `0xd9`, `0x5d`, and `0x11`, an error MUST be raised
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
+            </li>
+            <li>
+Initialize |components| to an array that is the result of CBOR-decoding the bytes
+that follow the three-byte Quantum-Safe-SD disclosure proof header. If the 
+result is not an array of the following six elements — 
+a byte array of length corresponding to the signature  size; 
+an array of byte arrays, each of length appropriate to the <em>salt size</em>;
+an array of byte arrays, each of length corresponding to the hash size; 
+a map of integers to byte arrays, each of length 32; 
+an array of integers; and another array of integers — an error MUST be raised
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
+            </li>
+            <li>
+Replace the fourth element in |components| using the result of calling the
+algorithm in 
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#decompresslabelmap">Section 3.5.6 
+decompressLabelMap</a> of [[VC-DI-ECDSA]], passing the existing
+fourth element of |components| as |compressedLabelMap|.
+            </li>
+            <li>
+Return <em>derived proof value</em> as an object with properties set to the five
+elements, using the names "signature", "salts", "saltedHashes",
+"labelMap", "mandatoryIndexes",  and "selectiveIndexes" respectively.
+            </li>
+          </ol>
+          <p class="ednote">
+Should we also mention additional checks on the values of |salts|, 
+|saltedHashes|, |mandatoryIndexes|, and |selectiveIndexes|? In particular, the
+length of the the |salts| and |saltedHashes| must be the same. The all elements
+of the |mandatoryIndexes| and |selectiveIndexes| should be in the range of 0 to
+the length of |salts|. There should not be repeated items in the 
+|mandatoryIndexes| and |selectiveIndexesArrays|. Also the elements of each of 
+these arrays should be increasing order.
+          </p>
+
+        </section>
+
       </section>
     </section>
     <section class="informative" id="SecurityConsiderations">

--- a/index.html
+++ b/index.html
@@ -2609,18 +2609,6 @@ data-cite="INFRA#nulls">Null</a>
         <section id="createverifydata">
           <h4>Create Verify Data</h4>
 
-          <p class="ednote">
-<strong>Work in Progress</strong>. Updating from [[VC-DI-ECDSA]] version.         
-          </p>
-<!-- 
-const createVerifyData = {
-  signature: bytesToHex(signature),
-  proofHash: bytesToHex(proofHash),
-  salts: salts.map(s => bytesToHex(s)),
-  saltedHashes: saltedHashes.map(sh => bytesToHex(sh)),
-  nonMandatory,
-  mandatoryHash: bytesToHex(mandatoryHash)
-}           -->
           <p>
 The following algorithm creates the data needed to perform verification of an
 Quantum-Safe-SD protected [=verifiable credential=]. The inputs include a JSON-LD
@@ -2628,7 +2616,7 @@ document (|document|), an Quantum-Safe-SD disclosure proof (|proof|),
 and any custom JSON-LD API options, such as a document loader. A single
 <em>verify data</em> object value is produced as output containing the following
 fields: "signature", "proofHash", "salts", "saltedHashes", "nonMandatory",
-and "mandatoryHash".
+"mandatoryHash", and "selectiveIndexes".
           </p>
 
           <ol class="algorithm">
@@ -2646,14 +2634,16 @@ and |selectiveIndexes| to the values associated with their property names in the
 object returned when calling the algorithm in Section
 [[[#parsederivedproofvalue]]], passing |proofValue| from |proof|.
             </li>
-            <!-- STOPPED HERE to work on parsing... -->
             <li>
 Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
-Section [[[#createlabelmapfunction]]].
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#createlabelmapfunction">Section 
+  3.4.3 createLabelMapFunction</a> of [[VC-DI-ECDSA]].
             </li>
             <li>
-Initialize |nquads| to the result of calling the algorithm of section
-[[[#labelreplacementcanonicalizejsonld]]], passing |document|,
+Initialize |nquads| to the result of calling the algorithm of 
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#labelreplacementcanonicalizejsonld">
+Section 3.4.2 labelReplacementCanonicalizeJsonLd</a>  of  [[VC-DI-ECDSA]],
+passing |document|,
 |labelMapFactoryFunction|, and any custom
 JSON-LD API options. Note: This step transforms the document into an array of
 canonical N-Quads with pseudorandom blank node identifiers based on |labelMap|.
@@ -2677,12 +2667,14 @@ Otherwise, add |nq| to |nonMandatory|.
               </ol>
             </li>
             <li>
-Initialize |mandatoryHash| to the result of calling the "hashMandatory"
-primitive, passing |mandatory|.
+Initialize |mandatoryHash| to the result of calling the algorithm of
+<a href="https://www.w3.org/TR/vc-di-ecdsa/#hashmandatorynquads">Section 3.4.17 
+hashMandatoryNQuads</a> of [[VC-DI-ECDSA]], passing |mandatory|.
             </li>
             <li>
-Return an object with properties matching |baseSignature|, |proofHash|,
-|publicKey|, |signatures|, |nonMandatory|, and |mandatoryHash|.
+Return an object with properties matching |signature|, |proofHash|,
+|salts|, |saltedHashes|, |nonMandatory|, |mandatoryHash|, and 
+|selectiveIndexes|.
             </li>
           </ol>
 


### PR DESCRIPTION
This PR is in response to issue https://github.com/w3c/vc-di-quantum-safe/issues/22 and provides an  "efficient", i.e., one  PQC signature approach to supporting selective disclosure functionality. Comments and suggestion welcome.  Particularly on whether to group  supporting PQC SD functions  separately.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/di-quantum-safe/pull/24.html" title="Last updated on May 15, 2026, 5:32 PM UTC (a2cea81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-quantum-safe/24/bc2a8c9...Wind4Greg:a2cea81.html" title="Last updated on May 15, 2026, 5:32 PM UTC (a2cea81)">Diff</a>