### PR TITLE
Fix short name and GitHub links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         specStatus: "ED",
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
-        shortName: "di-quantum-resistant",
+        shortName: "vc-di-quantum-resistant",
 
         // if you wish the publication date to be other than today, set this
         //publishDate:  "2023-11-14",
@@ -29,7 +29,7 @@
         // previousMaturity:  "WD",
 
         // if there a publicly available Editor's Draft, this is the link
-        edDraftURI: "https://w3c-ccg.github.io/di-quantum-resistant/",
+        edDraftURI: "https://w3c.github.io/vc-di-quantum-resistant/",
         //latestVersion: "https://www.w3.org/community/reports/credentials/CG-FINAL-di-quantum-safe-20260422/",
 
         // if this is a LCWD, uncomment and set the end of its review period
@@ -90,7 +90,7 @@
         // name (with the @w3c.org) of the public mailing to which comments are due
         //wgPublicList: "public-credentials",
 
-        github: "https://github.com/w3c-ccg/di-quantum-resistant/",
+        github: "https://github.com/w3c/vc-di-quantum-resistant",
 
         otherLinks: [],
 
@@ -206,19 +206,19 @@
         otherLinks: [{
           key: "Related Specifications",
           data: [{
-            value: "The Verifiable Credentials Data Model v2.0",
-            href: "https://www.w3.org/TR/vc-data-model-2.0/"
+            value: "The Verifiable Credentials Data Model",
+            href: "https://www.w3.org/TR/vc-data-model/"
           }, {
-            value: "Verifiable Credential Data Integrity v1.0",
+            value: "Verifiable Credential Data Integrity",
             href: "https://www.w3.org/TR/vc-data-integrity/"
           }, {
-            value: "The Elliptic Curve Digital Signature Algorithm Cryptosuites v1.0",
+            value: "The Elliptic Curve Digital Signature Algorithm Cryptosuites",
             href: "https://www.w3.org/TR/vc-di-ecdsa/"
           }, {
-            value: "The Edwards Digital Signature Algorithm Cryptosuites v1.0",
+            value: "The Edwards Digital Signature Algorithm Cryptosuites",
             href: "https://www.w3.org/TR/vc-di-eddsa/"
           }, {
-            value: "The BBS Digital Signature Algorithm Cryptosuites v1.0",
+            value: "The BBS Digital Signature Algorithm Cryptosuites",
             href: "https://www.w3.org/TR/vc-di-bbs/"
           }]
         }]


### PR DESCRIPTION
Short name  was incorrectly "di-quantum-resistant" fixed to "vc-di-quantum-resistant". Fixed  GitHub links to  "w3c" rather than  "w3c-ccg".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/di-quantum-safe/pull/27.html" title="Last updated on May 28, 2026, 3:54 PM UTC (8e8aad3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-quantum-resistant/27/f579363...Wind4Greg:8e8aad3.html" title="Last updated on May 28, 2026, 3:54 PM UTC (8e8aad3)">Diff</a>